### PR TITLE
Refine section skill digestion semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bookworm Digester
 
-Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, and emits concise topic-centric markdown artifacts plus an `INDEX.md` for downstream human or agent workflows.
+Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, and emits section-like skill files plus an `INDEX.md` for downstream human or agent workflows.
+
+Each output file is meant to behave like a reusable skill/topic for another agent: focused enough to stand alone, but still traceable back to the source material.
 
 ## Supported inputs
 
@@ -22,7 +24,8 @@ bookworm digest docs/*.txt \
   --output-dir out \
   --provider-kind openai \
   --model gpt-4.1-mini \
-  --api-key "$OPENAI_API_KEY"
+  --api-key "$OPENAI_API_KEY" \
+  --max-active-topics 16
 ```
 
 ## Ollama example
@@ -37,3 +40,7 @@ bookworm digest docs/*.txt \
 ```
 
 If `--ollama-port` is omitted, the CLI defaults to port `11434`.
+
+## Loop semantics
+
+The digester always keeps processing remaining chunks unless it hits `--max-batches`. The provider's `should_continue` flag is narrower: it tells the orchestrator whether the **currently visible** section-like topics likely continue into adjacent chunks, not whether the whole corpus is finished. That lets Bookworm export many skill files from long documents instead of stopping early after a few seemingly complete topics.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, and emits section-like skill files plus an `INDEX.md` for downstream human or agent workflows.
 
-Each output file is meant to behave like a reusable skill/topic for another agent: focused enough to stand alone, but still traceable back to the source material.
+Each output file is meant to behave like a reusable skill file for another agent: focused enough to stand alone, but still traceable back to the source material.
 
 ## Supported inputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -53,11 +53,11 @@ Bookworm Digester solves this by converting source material into:
 
 ### 5.1 Engineering Agents
 
-An engineering agent should be able to read `INDEX.md`, identify relevant skills/topics, then load only the linked markdown files needed for a coding task.
+An engineering agent should be able to read `INDEX.md`, identify relevant skill files, then load only the linked markdown files needed for a coding task.
 
 ### 5.2 Human Researchers or Analysts
 
-A human should be able to scan the index, open the most relevant skill/topic digests, and avoid reading full source files unless provenance indicates a deeper check is necessary.
+A human should be able to scan the index, open the most relevant skill files, and avoid reading full source files unless provenance indicates a deeper check is necessary.
 
 ### 5.3 Automation Pipelines
 
@@ -88,7 +88,7 @@ Other Python code should be able to call the library API to digest files as part
 
 For each successful digestion run, the system must write:
 
-1. **one markdown file per discovered section-like topic / skill**
+1. **one markdown file per discovered section-like skill**
 2. **`INDEX.md`**
 
 ### 7.2 Topic File Requirements
@@ -142,7 +142,7 @@ For each batch, the provider must return:
 - whether processing should continue
 - rationale
 
-The system must honor early stop requests only after a configurable minimum number of batches.
+The system may delay acting on provider completion hints until a configurable minimum number of batches has been processed.
 `should_continue` applies to the currently visible topics, not to the entire remaining corpus. If chunks remain, the system must continue digesting them unless `max_batches` has been reached.
 
 ### FR-6 Finalize Topics for Export
@@ -309,7 +309,7 @@ The system is considered acceptable when it can:
 3. Produce one or more chunks
 4. Call the provider through the abstract interface
 5. Accumulate at least one topic
-6. Write skill/topic markdown files
+6. Write skill-file markdown outputs
 7. Write `INDEX.md`
 8. Expose the same core behavior through CLI and library API
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2,7 +2,7 @@
 
 ## 1. Product Definition
 
-Bookworm Digester is a document digestion system that ingests heterogeneous files, progressively reads their content through an LLM-guided loop, and emits a compact set of markdown files plus a final `INDEX.md`. The output is optimized for two audiences:
+Bookworm Digester is a document digestion system that ingests heterogeneous files, progressively reads their content through an LLM-guided loop, and emits a corpus-sized set of markdown skill files plus a final `INDEX.md`. The output is optimized for two audiences:
 
 1. **humans** who need a fast map of the source material
 2. **downstream LLM agents** that need high-signal context without paying to reread the original corpus
@@ -20,7 +20,7 @@ Raw documents are expensive for people and LLMs to consume:
 
 Bookworm Digester solves this by converting source material into:
 
-- a small set of **topic-centric markdown digests**
+- a set of **section-like markdown skill files**
 - a single **`INDEX.md`** that tells readers what exists and what to read next
 
 ## 3. Goals
@@ -53,11 +53,11 @@ Bookworm Digester solves this by converting source material into:
 
 ### 5.1 Engineering Agents
 
-An engineering agent should be able to read `INDEX.md`, identify relevant topics, then load only the linked markdown files needed for a coding task.
+An engineering agent should be able to read `INDEX.md`, identify relevant skills/topics, then load only the linked markdown files needed for a coding task.
 
 ### 5.2 Human Researchers or Analysts
 
-A human should be able to scan the index, open the most relevant topic digests, and avoid reading full source files unless provenance indicates a deeper check is necessary.
+A human should be able to scan the index, open the most relevant skill/topic digests, and avoid reading full source files unless provenance indicates a deeper check is necessary.
 
 ### 5.3 Automation Pipelines
 
@@ -88,7 +88,7 @@ Other Python code should be able to call the library API to digest files as part
 
 For each successful digestion run, the system must write:
 
-1. **one markdown file per topic**
+1. **one markdown file per discovered section-like topic / skill**
 2. **`INDEX.md`**
 
 ### 7.2 Topic File Requirements
@@ -99,6 +99,8 @@ Each topic markdown file must contain:
 - a concise summary
 - a list of durable key points
 - a list of source references
+
+Each topic file should be independently useful as a reusable skill-style artifact for another agent.
 
 ### 7.3 INDEX.md Requirements
 
@@ -132,7 +134,7 @@ The system must split extracted sections into bounded chunks suitable for repeat
 
 The system must preserve a growing topic map across digestion batches so later prompts can build on earlier understanding.
 
-### FR-5 Let the LLM Decide on Continuation
+### FR-5 Let the LLM Advise on Topic Continuation
 
 For each batch, the provider must return:
 
@@ -141,6 +143,7 @@ For each batch, the provider must return:
 - rationale
 
 The system must honor early stop requests only after a configurable minimum number of batches.
+`should_continue` applies to the currently visible topics, not to the entire remaining corpus. If chunks remain, the system must continue digesting them unless `max_batches` has been reached.
 
 ### FR-6 Finalize Topics for Export
 
@@ -170,7 +173,7 @@ Generated summaries must prefer high-value, reusable facts over verbose restatem
 
 ### 9.2 Topic-Centric Organization
 
-Output should be organized around topics, not around raw chunks or page order.
+Output should be organized around section-like topics / skills, not around raw chunks or page order.
 
 ### 9.3 Provenance
 
@@ -187,7 +190,7 @@ The system must provide configuration knobs that let operators trade off:
 - cost
 - latency
 - recall
-- number of output topics
+- number of active topics kept in prompt context
 
 ## 10. CLI Requirements
 
@@ -209,7 +212,7 @@ It must also accept:
 - `--batch-size`
 - `--minimum-batches-before-stop`
 - `--max-batches`
-- `--max-topics`
+- `--max-active-topics` (with `--max-topics` retained as a compatibility alias)
 
 When `--provider-kind ollama` is selected, the CLI must:
 
@@ -248,6 +251,8 @@ Output:
 - `should_continue`
 - `rationale`
 
+The continuation decision answers: "do these visible topics likely continue into nearby chunks?" It does not authorize stopping before unseen chunks are processed.
+
 ### 12.2 Finalization Contract
 
 Input:
@@ -256,7 +261,7 @@ Input:
 
 Output:
 
-- finalized list of topics suitable for markdown export
+- finalized list of topics suitable for markdown export as reusable skill files
 
 ## 13. Markdown Quality Requirements
 
@@ -290,7 +295,7 @@ The initial implementation must support configuration of:
 - chunks per provider batch
 - minimum batches before early stopping
 - maximum batches
-- maximum topics
+- maximum active topics kept in prompt context
 - provider kind
 - model name
 - credential inputs
@@ -304,7 +309,7 @@ The system is considered acceptable when it can:
 3. Produce one or more chunks
 4. Call the provider through the abstract interface
 5. Accumulate at least one topic
-6. Write topic markdown files
+6. Write skill/topic markdown files
 7. Write `INDEX.md`
 8. Expose the same core behavior through CLI and library API
 
@@ -331,7 +336,7 @@ Every topic should be able to point back to source material through structured r
 
 ### 16.4 Cost Awareness
 
-Operators should be able to reduce provider usage by shrinking chunk sizes, batch counts, or topic counts.
+Operators should be able to reduce provider usage by shrinking chunk sizes, batch counts, or active topic counts.
 
 ### 16.5 Deterministic Core
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -9,7 +9,7 @@ Bookworm Digester is a Python package that converts heterogeneous document sourc
 3. **Chunking** converts document sections into bounded units for incremental LLM digestion.
 4. **Digest orchestration** loops through chunk batches, updating a topic map and asking the provider whether the currently visible topics likely continue into adjacent chunks.
 5. **Provider abstraction** isolates prompt construction from LLM transport details.
-6. **Artifact generation** writes one markdown file per discovered skill/topic plus a navigational `INDEX.md`.
+6. **Artifact generation** writes one markdown file per discovered skill file plus a navigational `INDEX.md`.
 
 This design keeps the core workflow stable while allowing new source types and new LLM backends to be added without rewriting the pipeline.
 
@@ -109,7 +109,7 @@ Chunks are designed to be provider-facing payloads that remain small enough for 
 
 ### 4.5 TopicDigest
 
-`TopicDigest` is the accumulated section-like skill/topic output:
+`TopicDigest` is the accumulated section-like skill-file output:
 
 - `slug`
 - `title`
@@ -333,7 +333,7 @@ Digest response shape:
       ]
     }
   ],
- "should_continue": true,
+  "should_continue": true,
   "rationale": "Need more context from adjacent sections for the current visible topic."
 }
 ```
@@ -437,7 +437,7 @@ Filename convention:
 - input source list
 - final stop reason from the orchestrator
 
-This file is the navigation layer meant to help another LLM or human quickly identify which skill/topic files matter.
+This file is the navigation layer meant to help another LLM or human quickly identify which skill files matter.
 
 ## 11. Public Interfaces
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -7,9 +7,9 @@ Bookworm Digester is a Python package that converts heterogeneous document sourc
 1. **Source adapters** extract raw content from each supported file type.
 2. **Canonical models** normalize extracted content into a shared structure.
 3. **Chunking** converts document sections into bounded units for incremental LLM digestion.
-4. **Digest orchestration** loops through chunk batches, updating a topic map and asking the provider whether more input is required.
+4. **Digest orchestration** loops through chunk batches, updating a topic map and asking the provider whether the currently visible topics likely continue into adjacent chunks.
 5. **Provider abstraction** isolates prompt construction from LLM transport details.
-6. **Artifact generation** writes one markdown file per topic plus a navigational `INDEX.md`.
+6. **Artifact generation** writes one markdown file per discovered skill/topic plus a navigational `INDEX.md`.
 
 This design keeps the core workflow stable while allowing new source types and new LLM backends to be added without rewriting the pipeline.
 
@@ -109,7 +109,7 @@ Chunks are designed to be provider-facing payloads that remain small enough for 
 
 ### 4.5 TopicDigest
 
-`TopicDigest` is the accumulated topic-centric output:
+`TopicDigest` is the accumulated section-like skill/topic output:
 
 - `slug`
 - `title`
@@ -131,7 +131,8 @@ The `merge()` method merges topic updates from successive LLM iterations by:
 - `batch_size`
 - `minimum_batches_before_stop`
 - `max_batches`
-- `max_topics`
+- `max_active_topics`
+- `max_topics` (compatibility alias for `max_active_topics`)
 
 This is the primary place to tune cost, latency, and recall.
 
@@ -250,9 +251,9 @@ The orchestrator lives in `src/digester/core/orchestrator.py`.
 1. Convert normalized documents into chunks
 2. Build batch windows using `batch_size`
 3. For each batch:
-   - pass current topics and new chunks to the provider
+   - pass the currently active topics and new chunks to the provider
    - merge returned topic updates into the in-memory topic map
-   - stop early when the provider indicates coverage is sufficient and the minimum batch threshold has been met
+   - treat `should_continue` as guidance about whether the visible topics likely continue into nearby chunks
 4. Ask the provider to finalize topics for export
 5. Return a `DigestResult`
 
@@ -262,7 +263,8 @@ The loop ends when any of the following happens:
 
 - all computed batches are processed
 - `max_batches` is reached
-- the provider returns `should_continue = false` and `minimum_batches_before_stop` has been satisfied
+
+Provider completion does not stop corpus traversal on its own. It only marks the current topic cluster as sufficiently covered.
 
 ### 7.3 Why the Loop Is "Adaptive"
 
@@ -273,7 +275,7 @@ The system does not simply summarize the entire corpus in one call. Instead, it 
 - total batches
 - new chunk payloads
 
-This allows the provider to accumulate understanding and decide whether enough evidence exists to stop or whether more input should be read.
+This allows the provider to accumulate understanding and decide whether visible topics likely need more nearby evidence, while the orchestrator still walks all remaining chunks unless `max_batches` interrupts it.
 
 ### 7.4 Merging Behavior
 
@@ -294,13 +296,13 @@ The digest system prompt asks the model to:
 - behave as a document digestion engine
 - keep output concise and durable
 - return strict JSON
-- decide whether more content should be processed
+- decide whether the visible topics likely need more adjacent chunks
 
 The user prompt includes:
 
 - the current topic map
 - the current chunk batch
-- hard constraints such as max topics and anti-duplication guidance
+- hard constraints such as max active topics and anti-duplication guidance
 
 ### 8.2 Finalization Prompt
 
@@ -308,7 +310,7 @@ The finalization step asks the model to:
 
 - refine and compress existing topic digests
 - preserve factual key points
-- return a JSON object with a `topics` list
+- return a JSON object with a `topics` list suitable for reusable skill files
 
 ### 8.3 Output Schema Expectations
 
@@ -331,8 +333,8 @@ Digest response shape:
       ]
     }
   ],
-  "should_continue": true,
-  "rationale": "Need more context from later sections."
+ "should_continue": true,
+  "rationale": "Need more context from adjacent sections for the current visible topic."
 }
 ```
 
@@ -418,8 +420,9 @@ Each topic file contains:
 
 1. H1 title
 2. compact summary paragraph
-3. `## Key points`
-4. `## Source references`
+3. `## Detailed takeaways`
+4. `## Source files`
+5. `## Source references`
 
 Filename convention:
 
@@ -434,7 +437,7 @@ Filename convention:
 - input source list
 - final stop reason from the orchestrator
 
-This file is the navigation layer meant to help another LLM or human quickly identify which detailed markdown files matter.
+This file is the navigation layer meant to help another LLM or human quickly identify which skill/topic files matter.
 
 ## 11. Public Interfaces
 

--- a/src/digester/core/models.py
+++ b/src/digester/core/models.py
@@ -94,7 +94,12 @@ class DigestConfig:
     batch_size: int = 2
     minimum_batches_before_stop: int = 2
     max_batches: int = 50
-    max_topics: int = 12
+    max_active_topics: int = 12
+    max_topics: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.max_topics is not None:
+            self.max_active_topics = self.max_topics
 
 
 @dataclass
@@ -170,7 +175,9 @@ class DigestResult:
 
 
 def ensure_topics_limited(topics: Sequence[TopicDigest], max_topics: int) -> List[TopicDigest]:
-    return list(topics[:max_topics])
+    if max_topics <= 0:
+        return []
+    return list(topics[-max_topics:])
 
 
 def collapse_topic_summary(summary: str) -> str:

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -43,10 +43,12 @@ class DigestOrchestrator:
         )
 
         topic_map: Dict[str, TopicDigest] = {}
+        active_topic_slugs: List[str] = []
         stop_reason = "Processed all available chunks."
+        available_batches = (len(chunks) + self.config.batch_size - 1) // self.config.batch_size
         total_batches = min(
             self.config.max_batches,
-            (len(chunks) + self.config.batch_size - 1) // self.config.batch_size,
+            available_batches,
         )
 
         for batch_index in range(total_batches):
@@ -54,7 +56,10 @@ class DigestOrchestrator:
             chunk_batch = chunks[start : start + self.config.batch_size]
             if not chunk_batch:
                 break
-            current_topics = ensure_topics_limited(list(topic_map.values()), self.config.max_topics)
+            current_topics = ensure_topics_limited(
+                [topic_map[slug] for slug in active_topic_slugs if slug in topic_map],
+                self.config.max_active_topics,
+            )
             batch_files = sorted({file_label(chunk.source_path) for chunk in chunk_batch})
             self.progress_reporter.update(
                 "Digesting batch {current}/{total} for {files}.".format(
@@ -75,9 +80,15 @@ class DigestOrchestrator:
                 existing = topic_map.get(update.slug)
                 if existing is None:
                     topic_map[update.slug] = update
+                    if update.slug in active_topic_slugs:
+                        active_topic_slugs.remove(update.slug)
+                    active_topic_slugs.append(update.slug)
                     continue
                 existing.merge(update)
                 existing.summary = collapse_topic_summary(existing.summary)
+                if update.slug in active_topic_slugs:
+                    active_topic_slugs.remove(update.slug)
+                active_topic_slugs.append(update.slug)
             self.progress_reporter.persist(
                 "Completed batch {current}/{total}; tracking {topics} topic(s).".format(
                     current=batch_index + 1,
@@ -89,23 +100,21 @@ class DigestOrchestrator:
                 not decision.should_continue
                 and batch_index + 1 >= self.config.minimum_batches_before_stop
             ):
-                stop_reason = decision.rationale or "Provider reported topic coverage was sufficient."
                 self.progress_reporter.persist(
-                    "Stopping after batch {current}/{total}: {reason}".format(
+                    "Batch {current}/{total} marked the current topic cluster as complete: {reason}".format(
                         current=batch_index + 1,
                         total=total_batches,
-                        reason=stop_reason,
+                        reason=decision.rationale
+                        or "Provider reported the visible section-like topics looked complete.",
                     )
                 )
-                break
 
         self.progress_reporter.update("Finalizing topic digests.")
-        topics = ensure_topics_limited(
-            self.provider.finalize_topics(list(topic_map.values())),
-            self.config.max_topics,
-        )
+        topics = self.provider.finalize_topics(list(topic_map.values()))
         if not topics:
             raise ValueError("The provider returned no topics for the supplied corpus.")
+        if total_batches < available_batches:
+            stop_reason = "Reached max_batches before processing all available chunks."
         self.progress_reporter.persist(
             "Finalized {count} topic digest(s).".format(count=len(topics))
         )

--- a/src/digester/core/prompts.py
+++ b/src/digester/core/prompts.py
@@ -8,16 +8,16 @@ from .models import DigestBatchRequest, TopicDigest
 
 def build_digest_system_prompt() -> str:
     return (
-        "You are a document digestion engine. Read the supplied chunks, update a topic-centric view of the corpus, "
-        "and decide whether processing should continue. Preserve high-value operational detail for downstream LLM agents, "
+        "You are a document digestion engine. Read the supplied chunks, update a section-like skill map of the corpus, "
+        "and decide whether the currently visible topics likely need more adjacent chunks before they are complete. Preserve high-value operational detail for downstream LLM agents, "
         "especially setup flows, hardware installation steps, wiring order, firmware or software prerequisites, commands, "
         "configuration values, validation checks, warnings, failure conditions, and recovery notes. "
         "Compress repetition, but do not compress away procedures, dependencies, sequencing, or concrete implementation detail. "
         "Return strict JSON with keys: topic_updates, should_continue, rationale. "
         "Each topic update must include slug, title, summary, key_points, references. "
         "references must contain source_id, source_path, locator. "
-        "Set should_continue to false only when the current topics already provide strong coverage of both the high-level themes "
-        "and the actionable step-by-step details in the visible corpus."
+        "Treat each topic like a section-level skill file that another agent could reuse on its own. "
+        "Set should_continue to false only when the current visible topics already have strong coverage and the next chunks are more likely to introduce different topics than extend these ones."
     )
 
 
@@ -47,18 +47,20 @@ def build_digest_user_prompt(request: DigestBatchRequest) -> str:
         "Current topics:\n{topics}\n\n"
         "New chunks:\n{chunks}\n\n"
         "Constraints:\n"
-        "- Keep at most {max_topics} durable topics.\n"
+        "- Keep at most {max_topics} active topics in view for this batch.\n"
+        "- Topics should behave like section-level skill files: each one should cover a coherent, reusable slice of the source rather than the whole corpus.\n"
         "- Summaries should be rich, actionable, and markdown-ready, usually 2-5 compact paragraphs when the material supports it.\n"
         "- Preserve setup sequences, hardware steps, prerequisites, commands, parameter values, safety notes, verification steps, and troubleshooting clues when present.\n"
         "- Key points should be concrete, fact-like, and numerous enough to preserve important detail; prefer roughly 5-12 bullets when the source is dense.\n"
         "- Merge overlapping ideas instead of creating duplicates.\n"
-        "- Favor detail that helps another engineer or agent reproduce the setup, understand the implementation, or avoid mistakes."
+        "- Favor detail that helps another engineer or agent reproduce the setup, understand the implementation, or avoid mistakes.\n"
+        "- Use should_continue=true when the visible topic still looks incomplete or likely continues in upcoming chunks. Use should_continue=false when these visible topics look complete even if later chunks may contain different topics."
     ).format(
         batch=request.batch_number,
         total=request.total_batches,
         topics=json.dumps(current_topics, indent=2),
         chunks=json.dumps(batch_payload, indent=2),
-        max_topics=request.config.max_topics,
+        max_topics=request.config.max_active_topics,
     )
 
 
@@ -67,7 +69,7 @@ def build_finalize_system_prompt() -> str:
         "You are preparing final topic digests for markdown export. "
         "Return strict JSON with a single key named topics. "
         "Each topic must include slug, title, summary, key_points, references. "
-        "Produce rich markdown-ready summaries that keep the most useful implementation and setup detail. "
+        "Produce rich markdown-ready summaries that keep the most useful implementation and setup detail. Each topic should read like a reusable skill file for another agent. "
         "Do not collapse away hardware setup flows, ordered procedures, commands, prerequisites, warnings, validation checks, or troubleshooting notes. "
         "Remove duplication, but preserve concrete facts and enough detail that another LLM or engineer could act on the output without rereading the whole source."
     )

--- a/src/digester/interfaces/api.py
+++ b/src/digester/interfaces/api.py
@@ -45,7 +45,7 @@ class DocumentDigester:
             progress_reporter=self.progress_reporter,
         )
         self.progress_reporter.persist(
-            "Finished digestion with {count} skill/topic file(s).".format(count=len(result.topics))
+            "Finished digestion with {count} skill file(s).".format(count=len(result.topics))
         )
         self.progress_reporter.clear()
         return result

--- a/src/digester/interfaces/api.py
+++ b/src/digester/interfaces/api.py
@@ -45,7 +45,7 @@ class DocumentDigester:
             progress_reporter=self.progress_reporter,
         )
         self.progress_reporter.persist(
-            "Finished digestion with {count} topic file(s).".format(count=len(result.topics))
+            "Finished digestion with {count} skill/topic file(s).".format(count=len(result.topics))
         )
         self.progress_reporter.clear()
         return result

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -50,7 +50,14 @@ def build_parser() -> argparse.ArgumentParser:
     digest_parser.add_argument("--batch-size", type=int, default=2)
     digest_parser.add_argument("--minimum-batches-before-stop", type=int, default=2)
     digest_parser.add_argument("--max-batches", type=int, default=50)
-    digest_parser.add_argument("--max-topics", type=int, default=12)
+    digest_parser.add_argument(
+        "--max-active-topics",
+        "--max-topics",
+        dest="max_active_topics",
+        type=int,
+        default=12,
+        help="Maximum number of recent section-like topics to include in each provider prompt.",
+    )
     return parser
 
 
@@ -93,13 +100,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             batch_size=args.batch_size,
             minimum_batches_before_stop=args.minimum_batches_before_stop,
             max_batches=args.max_batches,
-            max_topics=args.max_topics,
+            max_active_topics=args.max_active_topics,
         ),
         progress_reporter=reporter,
     )
     result = digester.digest_paths(args.inputs, args.output_dir)
     print(
-        "Wrote {count} topic files plus INDEX.md to {output_dir}".format(
+        "Wrote {count} skill/topic files plus INDEX.md to {output_dir}".format(
             count=len(result.topics),
             output_dir=args.output_dir,
         )

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -106,7 +106,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     result = digester.digest_paths(args.inputs, args.output_dir)
     print(
-        "Wrote {count} skill/topic files plus INDEX.md to {output_dir}".format(
+        "Wrote {count} skill files plus INDEX.md to {output_dir}".format(
             count=len(result.topics),
             output_dir=args.output_dir,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,12 +49,12 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "Wrote 1 skill/topic files plus INDEX.md" in captured.out
+    assert "Wrote 1 skill files plus INDEX.md" in captured.out
     assert (output_dir / "summary.md").exists()
     assert "Using provider openai with model fake-model." in captured.err
     assert "Loaded notes.txt with 1 section(s)." in captured.err
     assert "Completed batch 1/1; tracking 1 topic(s)." in captured.err
-    assert "Finished digestion with 1 skill/topic file(s)." in captured.err
+    assert "Finished digestion with 1 skill file(s)." in captured.err
     assert "Generated" in captured.err
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,11 +49,12 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "INDEX.md" in captured.out
+    assert "Wrote 1 skill/topic files plus INDEX.md" in captured.out
     assert (output_dir / "summary.md").exists()
     assert "Using provider openai with model fake-model." in captured.err
     assert "Loaded notes.txt with 1 section(s)." in captured.err
     assert "Completed batch 1/1; tracking 1 topic(s)." in captured.err
+    assert "Finished digestion with 1 skill/topic file(s)." in captured.err
     assert "Generated" in captured.err
 
 
@@ -96,3 +97,20 @@ def test_cli_passes_ollama_host_and_port(monkeypatch, tmp_path: Path, capsys) ->
         "ollama_port": 11555,
     }
     assert "Using provider ollama (192.168.1.10:11555) with model llama3.1." in captured.err
+
+
+def test_cli_max_topics_flag_is_kept_as_compatibility_alias() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "digest",
+            "notes.txt",
+            "--output-dir",
+            "artifacts",
+            "--model",
+            "fake-model",
+            "--max-topics",
+            "7",
+        ]
+    )
+
+    assert args.max_active_topics == 7

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -22,7 +22,7 @@ class FakeProvider(LLMProvider):
             ),
             key_points=[
                 "Uses adapters for ingestion",
-                "Emits topic-centric markdown",
+                "Emits section-like skill files",
                 "Preserves setup detail for downstream readers",
             ],
             references=[chunk.source_ref for chunk in request.chunk_batch],
@@ -63,8 +63,9 @@ def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
     output_dir = tmp_path / "out"
     reporter = RecordingReporter()
 
+    provider = FakeProvider()
     result = DocumentDigester(
-        provider=FakeProvider(),
+        provider=provider,
         config=DigestConfig(max_chunk_chars=70, batch_size=1, minimum_batches_before_stop=2),
         progress_reporter=reporter,
     ).digest_paths([input_path], output_dir)
@@ -78,8 +79,84 @@ def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
     assert "## Overview" in topic_text
     assert "## Detailed takeaways" in topic_text
     assert "## Source files" in topic_text
-    assert result.stop_reason == "Topic coverage is sufficient after two batches."
+    assert result.stop_reason == "Processed all available chunks."
+    assert provider.calls == 3
     persisted = [message for kind, message in reporter.messages if kind == "persist"]
     assert any("Loaded source.txt with 1 section(s)." == message for message in persisted)
     assert any("Prepared 3 chunk(s) from 1 document(s)." == message for message in persisted)
+    assert any("Completed batch 3/3; tracking 1 topic(s)." == message for message in persisted)
+    assert any("marked the current topic cluster as complete" in message for message in persisted)
+    assert any("Finished digestion with 1 skill/topic file(s)." == message for message in persisted)
     assert any("Generated " in message and "architecture.md" in message for message in persisted)
+
+
+class ManyTopicProvider(LLMProvider):
+    def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
+        chunk = request.chunk_batch[0]
+        batch_number = request.batch_number
+        return DigestDecision(
+            topic_updates=[
+                TopicDigest(
+                    slug="skill-{batch}".format(batch=batch_number),
+                    title="Skill {batch}".format(batch=batch_number),
+                    summary="Summary for chunk {batch}.".format(batch=batch_number),
+                    key_points=["Point {batch}".format(batch=batch_number)],
+                    references=[chunk.source_ref],
+                )
+            ],
+            should_continue=False,
+            rationale="This section-like skill is complete.",
+        )
+
+
+def test_document_digester_keeps_all_discovered_topics_for_export(tmp_path: Path) -> None:
+    input_path = tmp_path / "skills.txt"
+    input_path.write_text(
+        "Section one.\n\nSection two.\n\nSection three.",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+
+    result = DocumentDigester(
+        provider=ManyTopicProvider(),
+        config=DigestConfig(max_chunk_chars=20, batch_size=1, max_active_topics=1),
+    ).digest_paths([input_path], output_dir)
+
+    assert len(result.topics) == 3
+    assert [topic.slug for topic in result.topics] == ["skill-1", "skill-2", "skill-3"]
+    assert (output_dir / "skill-1.md").exists()
+    assert (output_dir / "skill-2.md").exists()
+    assert (output_dir / "skill-3.md").exists()
+
+
+class LimitedBatchProvider(LLMProvider):
+    def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
+        chunk = request.chunk_batch[0]
+        return DigestDecision(
+            topic_updates=[
+                TopicDigest(
+                    slug=chunk.chunk_id,
+                    title=chunk.chunk_id,
+                    summary="Summary",
+                    key_points=["Point"],
+                    references=[chunk.source_ref],
+                )
+            ],
+            should_continue=True,
+            rationale="Need more context.",
+        )
+
+
+def test_document_digester_reports_max_batches_limit(tmp_path: Path) -> None:
+    input_path = tmp_path / "source.txt"
+    input_path.write_text(
+        "One.\n\nTwo.\n\nThree.",
+        encoding="utf-8",
+    )
+
+    result = DocumentDigester(
+        provider=LimitedBatchProvider(),
+        config=DigestConfig(max_chunk_chars=8, batch_size=1, max_batches=2),
+    ).digest_paths([input_path], tmp_path / "out")
+
+    assert result.stop_reason == "Reached max_batches before processing all available chunks."

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -86,7 +86,7 @@ def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
     assert any("Prepared 3 chunk(s) from 1 document(s)." == message for message in persisted)
     assert any("Completed batch 3/3; tracking 1 topic(s)." == message for message in persisted)
     assert any("marked the current topic cluster as complete" in message for message in persisted)
-    assert any("Finished digestion with 1 skill/topic file(s)." == message for message in persisted)
+    assert any("Finished digestion with 1 skill file(s)." == message for message in persisted)
     assert any("Generated " in message and "architecture.md" in message for message in persisted)
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -11,7 +11,7 @@ from digester.core.prompts import (
 def test_digest_prompts_preserve_setup_and_hardware_detail() -> None:
     system_prompt = build_digest_system_prompt()
     request = DigestBatchRequest(
-        config=DigestConfig(max_topics=8),
+        config=DigestConfig(max_active_topics=8),
         batch_number=1,
         total_batches=3,
         chunk_batch=[
@@ -33,9 +33,12 @@ def test_digest_prompts_preserve_setup_and_hardware_detail() -> None:
     user_prompt = build_digest_user_prompt(request)
 
     assert "hardware installation steps" in system_prompt
+    assert "section-level skill file" in system_prompt
     assert "setup sequences" in user_prompt
     assert "verification steps" in user_prompt
     assert "5-12 bullets" in user_prompt
+    assert "active topics in view" in user_prompt
+    assert "later chunks may contain different topics" in user_prompt
 
 
 def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
@@ -60,5 +63,6 @@ def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
 
     assert "hardware setup flows" in system_prompt
     assert "commands, prerequisites, warnings, validation checks" in system_prompt
+    assert "reusable skill file" in system_prompt
     assert "Expand weak summaries" in user_prompt
     assert "setup flow, operational nuance, and important edge cases" in user_prompt


### PR DESCRIPTION
## Summary
- keep traversing remaining chunks while treating provider continuation as section-level guidance
- shift topic handling toward section-like skill files and separate active prompt context from exported outputs
- begin aligning README, spec, technical docs, CLI text, and tests with the new skill-file semantics

## Status
Partial backup PR requested before the remaining validation and cleanup work is finished.