### PR TITLE
Use environment and file-based API key inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,23 @@ Each output file is meant to behave like a reusable skill file for another agent
 ## CLI example
 
 ```bash
+export OPENAI_API_KEY=your-api-key
+
 bookworm digest docs/*.txt \
   --output-dir out \
   --provider-kind openai \
   --model gpt-4.1-mini \
-  --api-key "$OPENAI_API_KEY" \
+  --max-active-topics 16
+```
+
+You can also keep the key in a file and point the CLI at it:
+
+```bash
+bookworm digest docs/*.txt \
+  --output-dir out \
+  --provider-kind openai \
+  --model gpt-4.1-mini \
+  --api-key-file ~/.config/bookworm/openai.key \
   --max-active-topics 16
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -210,7 +210,8 @@ bookworm digest INPUT [INPUT ...] --output-dir OUT --model MODEL
 It must also accept:
 
 - `--provider-kind`
-- `--api-key`
+- `--api-key-file`
+- `--api-key-env`
 - `--base-url`
 - `--organization`
 - `--ollama-host`
@@ -220,6 +221,8 @@ It must also accept:
 - `--minimum-batches-before-stop`
 - `--max-batches`
 - `--max-active-topics` (with `--max-topics` retained as a compatibility alias)
+
+Hosted providers must load their API key from an environment variable (defaulting to `OPENAI_API_KEY`, with `--api-key-env` allowing an override) or from a file passed via `--api-key-file`. Raw API keys must not be accepted directly on the command line.
 
 When `--provider-kind ollama` is selected, the CLI must:
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -476,9 +476,13 @@ Supported command:
 bookworm digest INPUT [INPUT ...] \
   --output-dir OUT \
   --provider-kind openai \
-  --model gpt-4.1-mini \
-  --api-key "$OPENAI_API_KEY"
+  --model gpt-4.1-mini
 ```
+
+For hosted providers, the CLI reads credentials from `OPENAI_API_KEY` by default. It also supports:
+
+- `--api-key-env` to select a different environment variable
+- `--api-key-file` to read the API key from a file that contains only the key
 
 Tunable runtime parameters:
 
@@ -492,7 +496,8 @@ Provider-specific parameters:
 
 - `--provider-kind`
 - `--model`
-- `--api-key`
+- `--api-key-env`
+- `--api-key-file`
 - `--base-url`
 - `--organization`
 - `--ollama-host`

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+from pathlib import Path
 from typing import Optional, Sequence
 
 from ..core import DigestConfig
@@ -24,7 +25,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="LLM provider kind.",
     )
     digest_parser.add_argument("--model", required=True, help="Model name to invoke.")
-    digest_parser.add_argument("--api-key", default=os.getenv("OPENAI_API_KEY", ""), help="Provider API key.")
+    credential_parser = digest_parser.add_mutually_exclusive_group()
+    credential_parser.add_argument(
+        "--api-key-file",
+        help="Path to a file that contains only the provider API key.",
+    )
+    credential_parser.add_argument(
+        "--api-key-env",
+        help="Environment variable to read the provider API key from. Defaults to OPENAI_API_KEY.",
+    )
     digest_parser.add_argument(
         "--base-url",
         default=os.getenv("DIGESTER_BASE_URL", ""),
@@ -74,6 +83,31 @@ def _provider_message(args: argparse.Namespace) -> str:
     )
 
 
+def _read_api_key_file(path_value: str) -> str:
+    api_key = Path(path_value).read_text(encoding="utf-8").strip()
+    if not api_key:
+        raise ValueError("API key file is empty.")
+    if "\n" in api_key or "\r" in api_key:
+        raise ValueError("API key file must contain only the API key.")
+    return api_key
+
+
+def _resolve_api_key(args: argparse.Namespace) -> str:
+    if args.provider_kind == "ollama":
+        return ""
+    if args.api_key_file:
+        return _read_api_key_file(args.api_key_file)
+    env_var_name = args.api_key_env or "OPENAI_API_KEY"
+    api_key = os.getenv(env_var_name, "").strip()
+    if not api_key:
+        raise ValueError(
+            "An API key is required. Set {env_var} or pass --api-key-file.".format(
+                env_var=env_var_name
+            )
+        )
+    return api_key
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -86,7 +120,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ProviderSettings(
             provider_kind=args.provider_kind,
             model=args.model,
-            api_key=args.api_key,
+            api_key=_resolve_api_key(args),
             base_url=args.base_url or None,
             organization=args.organization or None,
             ollama_host=args.ollama_host,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
     input_path = tmp_path / "notes.txt"
     input_path.write_text("A concise document.", encoding="utf-8")
     output_dir = tmp_path / "artifacts"
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
 
     monkeypatch.setattr(
         cli,
@@ -42,8 +43,6 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
             str(output_dir),
             "--model",
             "fake-model",
-            "--api-key",
-            "fake-key",
         ]
     )
 
@@ -56,6 +55,69 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
     assert "Completed batch 1/1; tracking 1 topic(s)." in captured.err
     assert "Finished digestion with 1 skill file(s)." in captured.err
     assert "Generated" in captured.err
+
+
+def test_cli_reads_api_key_from_file(monkeypatch, tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    api_key_path = tmp_path / "openai.key"
+    api_key_path.write_text("file-key\n", encoding="utf-8")
+    seen = {}
+
+    def fake_create_provider(settings: ProviderSettings):
+        seen["api_key"] = settings.api_key
+        return CliFakeProvider()
+
+    monkeypatch.setattr(cli, "create_provider", fake_create_provider)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--model",
+            "fake-model",
+            "--api-key-file",
+            str(api_key_path),
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert seen["api_key"] == "file-key"
+
+
+def test_cli_reads_api_key_from_custom_environment_variable(monkeypatch, tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    seen = {}
+    monkeypatch.setenv("BOOKWORM_OPENAI_API_KEY", "custom-key")
+
+    def fake_create_provider(settings: ProviderSettings):
+        seen["api_key"] = settings.api_key
+        return CliFakeProvider()
+
+    monkeypatch.setattr(cli, "create_provider", fake_create_provider)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--model",
+            "fake-model",
+            "--api-key-env",
+            "BOOKWORM_OPENAI_API_KEY",
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert seen["api_key"] == "custom-key"
 
 
 def test_cli_passes_ollama_host_and_port(monkeypatch, tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- stop accepting raw API keys on the command line
- load hosted provider credentials from OPENAI_API_KEY by default or a custom env var via --api-key-env
- add --api-key-file and update docs and tests for the safer credential flow

## Testing
- PYTHONPATH=src .venv/bin/pytest -q