### PR TITLE
Flush completed topics incrementally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bookworm Digester
 
-Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, and emits section-like skill files plus an `INDEX.md` for downstream human or agent workflows.
+Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, writes completed section-like skill files as soon as a topic cluster is finalized, and emits an `INDEX.md` for downstream human or agent workflows.
 
 Each output file is meant to behave like a reusable skill file for another agent: focused enough to stand alone, but still traceable back to the source material.
 
@@ -55,4 +55,4 @@ If `--ollama-port` is omitted, the CLI defaults to port `11434`.
 
 ## Loop semantics
 
-The digester always keeps processing remaining chunks unless it hits `--max-batches`. The provider's `should_continue` flag is narrower: it tells the orchestrator whether the **currently visible** section-like topics likely continue into adjacent chunks, not whether the whole corpus is finished. That lets Bookworm export many skill files from long documents instead of stopping early after a few seemingly complete topics.
+The digester always keeps processing remaining chunks unless it hits `--max-batches`. The provider's `should_continue` flag is narrower: it tells the orchestrator whether the **currently visible** section-like topics likely continue into adjacent chunks, not whether the whole corpus is finished. When the provider marks the visible cluster complete, Bookworm finalizes and writes those topic files immediately, then continues scanning later chunks for new topics. That keeps long runs from holding every completed topic in memory until the very end.

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -254,8 +254,10 @@ The orchestrator lives in `src/digester/core/orchestrator.py`.
    - pass the currently active topics and new chunks to the provider
    - merge returned topic updates into the in-memory topic map
    - treat `should_continue` as guidance about whether the visible topics likely continue into nearby chunks
-4. Ask the provider to finalize topics for export
-5. Return a `DigestResult`
+4. When the provider marks the visible topic cluster complete, finalize that cluster for export and clear it from the active in-memory map
+5. Write completed topic files incrementally
+6. Finalize any remaining active topics after the last batch
+7. Return a `DigestResult`
 
 ### 7.2 Stop Conditions
 

--- a/src/digester/core/artifacts.py
+++ b/src/digester/core/artifacts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 
 from ..utils.progress import NoOpProgressReporter, ProgressReporter, file_label
 from .models import DigestResult, TopicDigest
@@ -101,6 +101,37 @@ def _render_index_markdown(result: DigestResult) -> str:
 
 
 class MarkdownArtifactWriter:
+    def write_topics(
+        self,
+        topics: Sequence[TopicDigest],
+        output_dir: Path,
+        progress_reporter: Optional[ProgressReporter] = None,
+    ) -> Dict[str, Path]:
+        reporter = progress_reporter or NoOpProgressReporter()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        artifact_paths: Dict[str, Path] = {}
+        for topic in topics:
+            topic_path = output_dir / "{slug}.md".format(slug=topic.slug)
+            reporter.update("Writing {name}.".format(name=file_label(topic_path)))
+            topic_path.write_text(_render_topic_markdown(topic), encoding="utf-8")
+            artifact_paths[topic.slug] = topic_path
+            reporter.persist("Generated {path}.".format(path=topic_path))
+        return artifact_paths
+
+    def write_index(
+        self,
+        result: DigestResult,
+        output_dir: Path,
+        progress_reporter: Optional[ProgressReporter] = None,
+    ) -> Path:
+        reporter = progress_reporter or NoOpProgressReporter()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        index_path = output_dir / "INDEX.md"
+        reporter.update("Writing {name}.".format(name=file_label(index_path)))
+        index_path.write_text(_render_index_markdown(result), encoding="utf-8")
+        reporter.persist("Generated {path}.".format(path=index_path))
+        return index_path
+
     def write(
         self,
         result: DigestResult,
@@ -109,18 +140,15 @@ class MarkdownArtifactWriter:
     ) -> Dict[str, Path]:
         reporter = progress_reporter or NoOpProgressReporter()
         reporter.persist("Writing artifacts to {path}.".format(path=output_dir))
-        output_dir.mkdir(parents=True, exist_ok=True)
-        artifact_paths: Dict[str, Path] = {}
-        for topic in result.topics:
-            topic_path = output_dir / "{slug}.md".format(slug=topic.slug)
-            reporter.update("Writing {name}.".format(name=file_label(topic_path)))
-            topic_path.write_text(_render_topic_markdown(topic), encoding="utf-8")
-            artifact_paths[topic.slug] = topic_path
-            reporter.persist("Generated {path}.".format(path=topic_path))
-        index_path = output_dir / "INDEX.md"
-        reporter.update("Writing {name}.".format(name=file_label(index_path)))
-        index_path.write_text(_render_index_markdown(result), encoding="utf-8")
-        artifact_paths["INDEX"] = index_path
-        reporter.persist("Generated {path}.".format(path=index_path))
+        artifact_paths = self.write_topics(
+            result.topics,
+            output_dir,
+            progress_reporter=reporter,
+        )
+        artifact_paths["INDEX"] = self.write_index(
+            result,
+            output_dir,
+            progress_reporter=reporter,
+        )
         result.artifact_paths = artifact_paths
         return artifact_paths

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Sequence
 
 from ..providers.base import LLMProvider
 from ..utils.progress import NoOpProgressReporter, ProgressReporter, file_label
@@ -27,7 +27,11 @@ class DigestOrchestrator:
         self.config = config or DigestConfig()
         self.progress_reporter = progress_reporter or NoOpProgressReporter()
 
-    def run(self, documents: List[SourceDocument]) -> DigestResult:
+    def run(
+        self,
+        documents: List[SourceDocument],
+        on_topics_finalized: Optional[Callable[[Sequence[TopicDigest]], None]] = None,
+    ) -> DigestResult:
         self.progress_reporter.update(
             "Chunking {count} loaded document(s).".format(count=len(documents))
         )
@@ -43,6 +47,8 @@ class DigestOrchestrator:
         )
 
         topic_map: Dict[str, TopicDigest] = {}
+        finalized_topics: Dict[str, TopicDigest] = {}
+        finalized_topic_order: List[str] = []
         active_topic_slugs: List[str] = []
         stop_reason = "Processed all available chunks."
         available_batches = (len(chunks) + self.config.batch_size - 1) // self.config.batch_size
@@ -50,6 +56,26 @@ class DigestOrchestrator:
             self.config.max_batches,
             available_batches,
         )
+
+        def flush_topic_cluster(reason: Optional[str] = None) -> None:
+            if not topic_map:
+                return
+            topics = self.provider.finalize_topics(list(topic_map.values()))
+            if not topics:
+                raise ValueError("The provider returned no topics for the supplied corpus.")
+            self.progress_reporter.persist(
+                "Finalized {count} topic digest(s).".format(count=len(topics))
+            )
+            if reason:
+                self.progress_reporter.persist(reason)
+            for topic in topics:
+                if topic.slug not in finalized_topics:
+                    finalized_topic_order.append(topic.slug)
+                finalized_topics[topic.slug] = topic
+            if on_topics_finalized is not None:
+                on_topics_finalized(topics)
+            topic_map.clear()
+            active_topic_slugs.clear()
 
         for batch_index in range(total_batches):
             start = batch_index * self.config.batch_size
@@ -100,24 +126,22 @@ class DigestOrchestrator:
                 not decision.should_continue
                 and batch_index + 1 >= self.config.minimum_batches_before_stop
             ):
-                self.progress_reporter.persist(
+                flush_topic_cluster(
                     "Batch {current}/{total} marked the current topic cluster as complete: {reason}".format(
                         current=batch_index + 1,
                         total=total_batches,
                         reason=decision.rationale
                         or "Provider reported the visible section-like topics looked complete.",
-                    )
+                    ),
                 )
 
         self.progress_reporter.update("Finalizing topic digests.")
-        topics = self.provider.finalize_topics(list(topic_map.values()))
+        flush_topic_cluster()
+        topics = [finalized_topics[slug] for slug in finalized_topic_order]
         if not topics:
             raise ValueError("The provider returned no topics for the supplied corpus.")
         if total_batches < available_batches:
             stop_reason = "Reached max_batches before processing all available chunks."
-        self.progress_reporter.persist(
-            "Finalized {count} topic digest(s).".format(count=len(topics))
-        )
         return DigestResult(
             documents=documents,
             chunks=chunks,

--- a/src/digester/interfaces/api.py
+++ b/src/digester/interfaces/api.py
@@ -34,16 +34,31 @@ class DocumentDigester:
             normalized_paths,
             progress_reporter=self.progress_reporter,
         )
+        self.progress_reporter.persist(
+            "Writing artifacts to {path}.".format(path=output_path)
+        )
+        artifact_paths = {}
+
+        def write_completed_topics(topics):
+            artifact_paths.update(
+                self.artifact_writer.write_topics(
+                    topics,
+                    output_path,
+                    progress_reporter=self.progress_reporter,
+                )
+            )
+
         result = DigestOrchestrator(
             provider=self.provider,
             config=self.config,
             progress_reporter=self.progress_reporter,
-        ).run(documents)
-        self.artifact_writer.write(
+        ).run(documents, on_topics_finalized=write_completed_topics)
+        artifact_paths["INDEX"] = self.artifact_writer.write_index(
             result,
             output_path,
             progress_reporter=self.progress_reporter,
         )
+        result.artifact_paths = artifact_paths
         self.progress_reporter.persist(
             "Finished digestion with {count} skill file(s).".format(count=len(result.topics))
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,6 +5,7 @@ from digester.core import DigestConfig
 from digester.core.models import DigestBatchRequest, DigestDecision, TopicDigest
 from digester.interfaces.api import DocumentDigester
 from digester.providers.base import LLMProvider
+from digester.core.artifacts import MarkdownArtifactWriter
 
 
 class FakeProvider(LLMProvider):
@@ -164,3 +165,67 @@ def test_document_digester_reports_max_batches_limit(tmp_path: Path) -> None:
     ).digest_paths([input_path], tmp_path / "out")
 
     assert result.stop_reason == "Reached max_batches before processing all available chunks."
+
+
+class FinalizeEachBatchProvider(LLMProvider):
+    def __init__(self) -> None:
+        self.finalize_calls: List[List[str]] = []
+
+    def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
+        chunk = request.chunk_batch[0]
+        return DigestDecision(
+            topic_updates=[
+                TopicDigest(
+                    slug="topic-{batch}".format(batch=request.batch_number),
+                    title="Topic {batch}".format(batch=request.batch_number),
+                    summary="Summary {batch}".format(batch=request.batch_number),
+                    key_points=["Point {batch}".format(batch=request.batch_number)],
+                    references=[chunk.source_ref],
+                )
+            ],
+            should_continue=False,
+            rationale="This topic is complete.",
+        )
+
+    def finalize_topics(self, topics: List[TopicDigest]) -> List[TopicDigest]:
+        self.finalize_calls.append([topic.slug for topic in topics])
+        return topics
+
+
+class RecordingArtifactWriter(MarkdownArtifactWriter):
+    def __init__(self) -> None:
+        self.topic_batches: List[List[str]] = []
+        self.index_writes = 0
+
+    def write_topics(self, topics, output_dir, progress_reporter=None):
+        self.topic_batches.append([topic.slug for topic in topics])
+        return super().write_topics(topics, output_dir, progress_reporter)
+
+    def write_index(self, result, output_dir, progress_reporter=None):
+        self.index_writes += 1
+        return super().write_index(result, output_dir, progress_reporter)
+
+
+def test_document_digester_flushes_completed_topics_incrementally(tmp_path: Path) -> None:
+    input_path = tmp_path / "topics.txt"
+    input_path.write_text(
+        "Topic one.\n\nTopic two.\n\nTopic three.",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+    provider = FinalizeEachBatchProvider()
+    writer = RecordingArtifactWriter()
+
+    result = DocumentDigester(
+        provider=provider,
+        config=DigestConfig(max_chunk_chars=20, batch_size=1, minimum_batches_before_stop=1),
+        artifact_writer=writer,
+    ).digest_paths([input_path], output_dir)
+
+    assert provider.finalize_calls == [["topic-1"], ["topic-2"], ["topic-3"]]
+    assert writer.topic_batches == [["topic-1"], ["topic-2"], ["topic-3"]]
+    assert writer.index_writes == 1
+    assert [topic.slug for topic in result.topics] == ["topic-1", "topic-2", "topic-3"]
+    assert (output_dir / "topic-1.md").exists()
+    assert (output_dir / "topic-2.md").exists()
+    assert (output_dir / "topic-3.md").exists()


### PR DESCRIPTION
## Summary
- finalize completed topic clusters during traversal instead of keeping every topic in memory
- write topic markdown files incrementally and leave INDEX.md generation to the end
- add coverage for per-topic-cluster flushing and update the docs

## Testing
- PYTHONPATH=src .venv/bin/pytest -q