### PR TITLE
Fail fast on inaccessible OpenAI models

### DIFF
--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -115,34 +115,40 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         parser.error("Unknown command.")
 
     reporter = ConsoleProgressReporter()
-    reporter.persist(_provider_message(args))
-    provider = create_provider(
-        ProviderSettings(
-            provider_kind=args.provider_kind,
-            model=args.model,
-            api_key=_resolve_api_key(args),
-            base_url=args.base_url or None,
-            organization=args.organization or None,
-            ollama_host=args.ollama_host,
-            ollama_port=args.ollama_port,
+    try:
+        reporter.persist(_provider_message(args))
+        provider = create_provider(
+            ProviderSettings(
+                provider_kind=args.provider_kind,
+                model=args.model,
+                api_key=_resolve_api_key(args),
+                base_url=args.base_url or None,
+                organization=args.organization or None,
+                ollama_host=args.ollama_host,
+                ollama_port=args.ollama_port,
+            )
         )
-    )
-    digester = DocumentDigester(
-        provider=provider,
-        config=DigestConfig(
-            max_chunk_chars=args.max_chunk_chars,
-            batch_size=args.batch_size,
-            minimum_batches_before_stop=args.minimum_batches_before_stop,
-            max_batches=args.max_batches,
-            max_active_topics=args.max_active_topics,
-        ),
-        progress_reporter=reporter,
-    )
-    result = digester.digest_paths(args.inputs, args.output_dir)
-    print(
-        "Wrote {count} skill files plus INDEX.md to {output_dir}".format(
-            count=len(result.topics),
-            output_dir=args.output_dir,
+        provider.validate_configuration()
+        digester = DocumentDigester(
+            provider=provider,
+            config=DigestConfig(
+                max_chunk_chars=args.max_chunk_chars,
+                batch_size=args.batch_size,
+                minimum_batches_before_stop=args.minimum_batches_before_stop,
+                max_batches=args.max_batches,
+                max_active_topics=args.max_active_topics,
+            ),
+            progress_reporter=reporter,
         )
-    )
-    return 0
+        result = digester.digest_paths(args.inputs, args.output_dir)
+        print(
+            "Wrote {count} skill files plus INDEX.md to {output_dir}".format(
+                count=len(result.topics),
+                output_dir=args.output_dir,
+            )
+        )
+        return 0
+    except ValueError as error:
+        reporter.clear()
+        reporter.persist("Error: {message}".format(message=error))
+        return 1

--- a/src/digester/providers/base.py
+++ b/src/digester/providers/base.py
@@ -7,6 +7,9 @@ from ..core.models import DigestBatchRequest, DigestDecision, TopicDigest
 
 
 class LLMProvider(ABC):
+    def validate_configuration(self) -> None:
+        return None
+
     @abstractmethod
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
         raise NotImplementedError

--- a/src/digester/providers/openai_compatible.py
+++ b/src/digester/providers/openai_compatible.py
@@ -8,3 +8,6 @@ class OpenAICompatibleProvider(OpenAIProvider):
         if not base_url:
             raise ValueError("A base URL is required for openai-compatible providers.")
         super().__init__(model=model, api_key=api_key, base_url=base_url)
+
+    def validate_configuration(self) -> None:
+        return None

--- a/src/digester/providers/openai_provider.py
+++ b/src/digester/providers/openai_provider.py
@@ -38,16 +38,91 @@ class OpenAIProvider(LLMProvider):
             organization=self.organization,
         )
 
+    def _raise_openai_error(self, error: Exception) -> None:
+        from openai import (
+            APIConnectionError,
+            APITimeoutError,
+            AuthenticationError,
+            BadRequestError,
+            NotFoundError,
+            PermissionDeniedError,
+            RateLimitError,
+        )
+
+        detail = str(error)
+        body = getattr(error, "body", None)
+        error_payload = body.get("error", {}) if isinstance(body, dict) else {}
+        error_message = error_payload.get("message", "")
+        error_code = error_payload.get("code", "")
+        if isinstance(error, AuthenticationError):
+            raise ValueError(
+                "OpenAI authentication failed. Check the API key and organization settings."
+            ) from error
+        if isinstance(error, PermissionDeniedError):
+            if (
+                "does not have access to model" in detail
+                or "does not have access to model" in error_message
+                or error_code == "model_not_found"
+            ):
+                raise ValueError(
+                    "OpenAI project does not have access to model {model}. "
+                    "Choose a model enabled for this project or use a different API key."
+                    .format(model=self.model)
+                ) from error
+            raise ValueError(
+                "OpenAI denied access while using model {model}: {detail}".format(
+                    model=self.model,
+                    detail=detail,
+                )
+            ) from error
+        if isinstance(error, NotFoundError):
+            raise ValueError(
+                "OpenAI could not find model {model}. Check the model name and project access."
+                .format(model=self.model)
+            ) from error
+        if isinstance(error, BadRequestError):
+            raise ValueError(
+                "OpenAI rejected the request for model {model}: {detail}".format(
+                    model=self.model,
+                    detail=detail,
+                )
+            ) from error
+        if isinstance(error, RateLimitError):
+            raise ValueError(
+                "OpenAI rate limited requests for model {model}: {detail}".format(
+                    model=self.model,
+                    detail=detail,
+                )
+            ) from error
+        if isinstance(error, (APIConnectionError, APITimeoutError)):
+            raise ValueError(
+                "Unable to reach OpenAI for model {model}: {detail}".format(
+                    model=self.model,
+                    detail=detail,
+                )
+            ) from error
+        raise error
+
+    def validate_configuration(self) -> None:
+        client = self._client()
+        try:
+            client.models.retrieve(self.model)
+        except Exception as error:
+            self._raise_openai_error(error)
+
     def _complete_json(self, system_prompt: str, user_prompt: str) -> Dict[str, object]:
         client = self._client()
-        response = client.chat.completions.create(
-            model=self.model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            response_format={"type": "json_object"},
-        )
+        try:
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                response_format={"type": "json_object"},
+            )
+        except Exception as error:
+            self._raise_openai_error(error)
         content = response.choices[0].message.content
         if not content:
             raise ValueError("Model returned an empty response.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,12 @@ from digester.providers.base import LLMProvider
 
 
 class CliFakeProvider(LLMProvider):
+    def __init__(self) -> None:
+        self.validation_calls = 0
+
+    def validate_configuration(self) -> None:
+        self.validation_calls += 1
+
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
         return DigestDecision(
             topic_updates=[
@@ -55,6 +61,59 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
     assert "Completed batch 1/1; tracking 1 topic(s)." in captured.err
     assert "Finished digestion with 1 skill file(s)." in captured.err
     assert "Generated" in captured.err
+
+
+def test_cli_validates_provider_before_digestion(monkeypatch, tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    provider = CliFakeProvider()
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    monkeypatch.setattr(cli, "create_provider", lambda settings: provider)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--model",
+            "fake-model",
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert provider.validation_calls == 1
+
+
+def test_cli_reports_validation_errors_without_traceback(monkeypatch, tmp_path: Path, capsys) -> None:
+    class FailingProvider(CliFakeProvider):
+        def validate_configuration(self) -> None:
+            raise ValueError("OpenAI project does not have access to model fake-model.")
+
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    monkeypatch.setattr(cli, "create_provider", lambda settings: FailingProvider())
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--model",
+            "fake-model",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Error: OpenAI project does not have access to model fake-model." in captured.err
+    assert "Starting digestion" not in captured.err
+    assert captured.out == ""
 
 
 def test_cli_reads_api_key_from_file(monkeypatch, tmp_path: Path, capsys) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,11 +1,15 @@
 import json
+from types import SimpleNamespace
 from urllib.error import URLError
 
+import httpx
 import pytest
+from openai import PermissionDeniedError
 
 from digester.core.models import DigestBatchRequest, DigestConfig, SourceRef, TopicDigest
 from digester.providers import ProviderSettings, create_provider
 from digester.providers.ollama_provider import OllamaProvider, _normalize_base_url
+from digester.providers.openai_provider import OpenAIProvider
 
 
 def test_create_provider_builds_ollama_provider() -> None:
@@ -102,4 +106,60 @@ def test_ollama_provider_reports_connection_failure(monkeypatch) -> None:
                     references=[SourceRef(source_id="source", source_path="/tmp/source.txt", locator="full-document")],
                 )
             ]
+        )
+
+
+def test_openai_provider_validate_configuration_reports_model_access(monkeypatch) -> None:
+    provider = OpenAIProvider(model="gpt-5-nano", api_key="test-key")
+    request = httpx.Request("GET", "https://api.openai.com/v1/models/gpt-5-nano")
+    response = httpx.Response(
+        403,
+        request=request,
+        json={
+            "error": {
+                "message": "Project `proj_test` does not have access to model `gpt-5-nano`",
+                "code": "model_not_found",
+            }
+        },
+    )
+    error = PermissionDeniedError("Error code: 403", response=response, body=response.json())
+    fake_client = SimpleNamespace(
+        models=SimpleNamespace(retrieve=lambda model: (_ for _ in ()).throw(error))
+    )
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    with pytest.raises(ValueError, match="does not have access to model gpt-5-nano"):
+        provider.validate_configuration()
+
+
+def test_openai_provider_digest_batch_reports_model_access(monkeypatch) -> None:
+    provider = OpenAIProvider(model="gpt-5-nano", api_key="test-key")
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(
+        403,
+        request=request,
+        json={
+            "error": {
+                "message": "Project `proj_test` does not have access to model `gpt-5-nano`",
+                "code": "model_not_found",
+            }
+        },
+    )
+    error = PermissionDeniedError("Error code: 403", response=response, body=response.json())
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kwargs: (_ for _ in ()).throw(error))
+        )
+    )
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    with pytest.raises(ValueError, match="does not have access to model gpt-5-nano"):
+        provider.digest_batch(
+            DigestBatchRequest(
+                config=DigestConfig(),
+                batch_number=1,
+                total_batches=1,
+                chunk_batch=[],
+                current_topics=[],
+            )
         )


### PR DESCRIPTION
## Summary
- validate OpenAI model access before starting document digestion
- translate common OpenAI API failures into clear user-facing CLI errors
- add regression coverage for provider validation and model access failures

## Testing
- PYTHONPATH=src .venv/bin/pytest -q