### PR TITLE
Add agent-native skill export layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # Bookworm Digester
 
-Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, writes completed section-like skill files as soon as a topic cluster is finalized, and emits an `INDEX.md` for downstream human or agent workflows.
+Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, and writes completed section-like skill files into agent-native skill directories for downstream Copilot, OpenCode, and Codex workflows.
 
 Each output file is meant to behave like a reusable skill file for another agent: focused enough to stand alone, but still traceable back to the source material.
+
+By default, each run writes three directories beneath the chosen output directory:
+
+```text
+out/
+├── copilot/.github/skills/<skill-name>/SKILL.md
+├── opencode/.opencode/skills/<skill-name>/SKILL.md
+└── codex/.agents/skills/<skill-name>/SKILL.md
+```
 
 ## Supported inputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2,7 +2,7 @@
 
 ## 1. Product Definition
 
-Bookworm Digester is a document digestion system that ingests heterogeneous files, progressively reads their content through an LLM-guided loop, and emits a corpus-sized set of markdown skill files plus a final `INDEX.md`. The output is optimized for two audiences:
+Bookworm Digester is a document digestion system that ingests heterogeneous files, progressively reads their content through an LLM-guided loop, and emits agent-native skill directories for downstream tools such as Copilot, OpenCode, and Codex. The output is optimized for two audiences:
 
 1. **humans** who need a fast map of the source material
 2. **downstream LLM agents** that need high-signal context without paying to reread the original corpus
@@ -21,7 +21,7 @@ Raw documents are expensive for people and LLMs to consume:
 Bookworm Digester solves this by converting source material into:
 
 - a set of **section-like markdown skill files**
-- a single **`INDEX.md`** that tells readers what exists and what to read next
+- a set of **agent-native skill directory trees** that make those skills directly loadable by supported agent tools
 
 ## 3. Goals
 
@@ -53,11 +53,11 @@ Bookworm Digester solves this by converting source material into:
 
 ### 5.1 Engineering Agents
 
-An engineering agent should be able to read `INDEX.md`, identify relevant skill files, then load only the linked markdown files needed for a coding task.
+An engineering agent should be able to discover the generated `SKILL.md` files from its native skill root, use their descriptions to decide what to load, then read only the relevant skill bodies needed for a coding task.
 
 ### 5.2 Human Researchers or Analysts
 
-A human should be able to scan the index, open the most relevant skill files, and avoid reading full source files unless provenance indicates a deeper check is necessary.
+A human should be able to scan the generated skill directories, open the most relevant skill files, and avoid reading full source files unless provenance indicates a deeper check is necessary.
 
 ### 5.3 Automation Pipelines
 
@@ -86,33 +86,34 @@ Other Python code should be able to call the library API to digest files as part
 
 ### 7.1 Required Outputs
 
-For each successful digestion run, the system must write:
+For each successful digestion run, the system must write three agent-targeted output directories by default:
 
-1. **one markdown file per discovered section-like skill**
-2. **`INDEX.md`**
+1. **`copilot/.github/skills/<skill>/SKILL.md`**
+2. **`opencode/.opencode/skills/<skill>/SKILL.md`**
+3. **`codex/.agents/skills/<skill>/SKILL.md`**
 
 ### 7.2 Topic File Requirements
 
-Each topic markdown file must contain:
+Each generated `SKILL.md` file must contain:
 
 - a stable topic title
+- YAML frontmatter with the skill name and routing description
 - when-to-use guidance that tells a downstream agent when to load the skill
 - a concise purpose summary
 - a list of durable, actionable core instructions
 - workflow notes for using the skill safely with live repository context
 - a list of source references
 
-Each topic file should be independently useful as a reusable skill-style artifact for coding agents such as Codex, Claude Code, and Copilot.
+Each topic file should be independently useful as a reusable skill-style artifact for coding agents such as Codex, Claude Code, Copilot, and OpenCode.
 
-### 7.3 INDEX.md Requirements
+### 7.3 Agent Export Layout Requirements
 
-`INDEX.md` must contain:
+The agent export layer must:
 
-- links to generated topic files
-- routing guidance that tells agents which skill file to load for a task
-- a short preview line for each skill
-- the list of original source inputs
-- a textual stop reason describing why the digestion loop ended
+- create one directory per supported agent target
+- arrange each skill as `<agent-root>/<skill-name>/SKILL.md` beneath that tool's native discovery path
+- preserve routing guidance in `SKILL.md` frontmatter descriptions and body content
+- preserve source provenance inside each generated skill body
 
 ## 8. Functional Requirements
 
@@ -180,7 +181,7 @@ Output should be organized around section-like topics / skills, not around raw c
 
 ### 9.2.1 Agent-Skill Usability
 
-Generated files should help coding agents decide what to read and how to act. `INDEX.md` should behave as the router, while each skill file should state when to use it, what instructions matter, what workflow notes or caveats apply, and where to verify source provenance.
+Generated files should help coding agents decide what to read and how to act. The skill directory layout plus each `SKILL.md` description should behave as the router, while each skill file should state when to use it, what instructions matter, what workflow notes or caveats apply, and where to verify source provenance.
 
 ### 9.3 Provenance
 
@@ -319,8 +320,8 @@ The system is considered acceptable when it can:
 3. Produce one or more chunks
 4. Call the provider through the abstract interface
 5. Accumulate at least one topic
-6. Write skill-file markdown outputs
-7. Write `INDEX.md`
+6. Write skill-file markdown outputs in supported agent-native layouts
+7. Emit the default Copilot, OpenCode, and Codex export trees
 8. Expose the same core behavior through CLI and library API
 
 ## 16. Quality Attributes
@@ -400,4 +401,4 @@ Bookworm Digester is specified as a **multi-format, LLM-guided context compresso
 - adaptive digestion loop
 - provider abstraction
 - concise markdown outputs
-- navigational `INDEX.md`
+- agent-native skill directory exports

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -9,7 +9,7 @@ Bookworm Digester is a Python package that converts heterogeneous document sourc
 3. **Chunking** converts document sections into bounded units for incremental LLM digestion.
 4. **Digest orchestration** loops through chunk batches, updating a topic map and asking the provider whether the currently visible topics likely continue into adjacent chunks.
 5. **Provider abstraction** isolates prompt construction from LLM transport details.
-6. **Artifact generation** writes one markdown file per discovered skill file plus a navigational `INDEX.md`.
+6. **Artifact generation** writes agent-native `SKILL.md` exports for the supported Copilot, OpenCode, and Codex directory layouts.
 
 This design keeps the core workflow stable while allowing new source types and new LLM backends to be added without rewriting the pipeline.
 
@@ -416,33 +416,26 @@ This makes local-model development straightforward without forcing users through
 
 Markdown writing lives in `src/digester/core/artifacts.py`.
 
-### 10.1 Topic Files
+### 10.1 Agent Skill Files
 
-Each topic file contains:
+Each generated `SKILL.md` contains:
 
-1. H1 title
-2. `## When To Use`
-3. `## Purpose`
-4. `## Core Instructions`
-5. `## Workflow Notes`
-6. `## Source files`
-7. `## Source references`
+1. YAML frontmatter with `name` and `description`
+2. H1 title
+3. `## When To Use`
+4. `## Purpose`
+5. `## Core Instructions`
+6. `## Workflow Notes`
+7. `## Source files`
+8. `## Source references`
 
-Filename convention:
+Directory conventions:
 
-- `{slug}.md`
+- `copilot/.github/skills/{slug}/SKILL.md`
+- `opencode/.opencode/skills/{slug}/SKILL.md`
+- `codex/.agents/skills/{slug}/SKILL.md`
 
-### 10.2 INDEX.md
-
-`INDEX.md` contains:
-
-- skill routing guidance
-- skill links
-- first-line skill summary preview
-- input source list
-- final stop reason from the orchestrator
-
-This file is the navigation layer meant to help a coding agent or human quickly identify which skill files matter before loading only the relevant markdown artifacts.
+The description/frontmatter acts as the routing layer for downstream agents, so the runtime no longer emits a separate top-level `INDEX.md`.
 
 ## 11. Public Interfaces
 
@@ -467,6 +460,8 @@ provider = create_provider(
 digester = DocumentDigester(provider=provider)
 result = digester.digest_paths(["./docs/report.pdf"], "./out")
 ```
+
+`result.artifact_paths` contains the generated agent root directories (`copilot`, `opencode`, `codex`) plus per-skill `SKILL.md` paths keyed as `<agent>:<topic-slug>`.
 
 ### 11.2 CLI
 

--- a/src/digester/core/artifacts.py
+++ b/src/digester/core/artifacts.py
@@ -1,10 +1,31 @@
 from __future__ import annotations
 
+import json
+import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Set, Tuple
 
 from ..utils.progress import NoOpProgressReporter, ProgressReporter, file_label
 from .models import DigestResult, TopicDigest
+
+
+@dataclass(frozen=True)
+class AgentSkillLayout:
+    agent_name: str
+    skills_path_parts: Tuple[str, ...]
+    compatibility: Optional[str] = None
+
+
+DEFAULT_AGENT_LAYOUTS: Tuple[AgentSkillLayout, ...] = (
+    AgentSkillLayout(agent_name="copilot", skills_path_parts=(".github", "skills")),
+    AgentSkillLayout(
+        agent_name="opencode",
+        skills_path_parts=(".opencode", "skills"),
+        compatibility="opencode",
+    ),
+    AgentSkillLayout(agent_name="codex", skills_path_parts=(".agents", "skills")),
+)
 
 
 def _unique_source_paths(topic: TopicDigest):
@@ -18,16 +39,21 @@ def _unique_source_paths(topic: TopicDigest):
     return ordered
 
 
-def _render_topic_markdown(topic: TopicDigest) -> str:
+def _topic_routing_description(topic: TopicDigest) -> str:
+    summary = topic.summary.strip()
+    first_line = next((line.strip() for line in summary.splitlines() if line.strip()), topic.title)
+    normalized = first_line.rstrip(".")
+    return "Use this skill when work requires {summary}.".format(summary=normalized)
+
+
+def _render_skill_body(topic: TopicDigest) -> str:
     summary = topic.summary.strip()
     lines = [
         "# {title}".format(title=topic.title),
         "",
         "## When To Use",
         "",
-        "Use this skill when work requires the source-backed guidance captured in this topic: {summary}".format(
-            summary=summary.splitlines()[0] if summary else topic.title
-        ),
+        _topic_routing_description(topic),
         "",
         "## Purpose",
         "",
@@ -42,7 +68,7 @@ def _render_topic_markdown(topic: TopicDigest) -> str:
             "",
             "## Workflow Notes",
             "",
-            "- Load this skill before acting on tasks that match the routing guidance in `INDEX.md`.",
+            "- Load this skill when the task matches the frontmatter description and the guidance below.",
             "- Treat the instructions above as source-backed context, not as a replacement for checking current repository code.",
             "- Use the source references when a decision depends on exact wording, provenance, or missing detail.",
         ]
@@ -57,50 +83,48 @@ def _render_topic_markdown(topic: TopicDigest) -> str:
     return "\n".join(lines)
 
 
-def _render_index_markdown(result: DigestResult) -> str:
-    lines = [
-        "# Index",
-        "",
-        "Generated skill map for downstream coding agents and human readers.",
-        "",
-        "Use this file as the router: identify the task you are doing, load the matching skill files, then use their source references when exact provenance matters.",
-        "",
-        "## Skill Routing",
-        "",
+def _normalize_skill_dir_name(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    normalized = re.sub(r"-{2,}", "-", normalized)
+    return normalized or "skill"
+
+
+def _render_skill_markdown(
+    topic: TopicDigest,
+    layout: AgentSkillLayout,
+    skill_dir_name: str,
+) -> str:
+    frontmatter_lines = [
+        "---",
+        "name: {name}".format(name=skill_dir_name),
+        "description: {description}".format(description=json.dumps(_topic_routing_description(topic))),
     ]
-    for topic in result.topics:
-        file_name = "{slug}.md".format(slug=topic.slug)
-        preview_lines = [line.strip() for line in topic.summary.splitlines() if line.strip()]
-        preview = " ".join(preview_lines[:2])
-        lines.append(
-            "- Use [{title}]({file_name}) when the task involves: {summary}".format(
-                title=topic.title,
-                file_name=file_name,
-                summary=preview,
-            )
-        )
-    lines.extend(
-        [
-            "",
-            "## Source inputs",
-            "",
-        ]
-    )
-    for document in result.documents:
-        lines.append("- `{path}`".format(path=document.path_str))
-    lines.extend(
-        [
-            "",
-            "## Stop reason",
-            "",
-            result.stop_reason,
-            "",
-        ]
-    )
-    return "\n".join(lines)
+    if layout.compatibility:
+        frontmatter_lines.append("compatibility: {compatibility}".format(compatibility=layout.compatibility))
+    frontmatter_lines.extend(["---", ""])
+    return "\n".join(frontmatter_lines) + _render_skill_body(topic)
 
 
 class MarkdownArtifactWriter:
+    def __init__(self, agent_layouts: Sequence[AgentSkillLayout] = DEFAULT_AGENT_LAYOUTS) -> None:
+        self.agent_layouts = tuple(agent_layouts)
+        self._skill_dir_names: Dict[str, str] = {}
+        self._used_skill_dir_names: Set[str] = set()
+
+    def _skill_dir_name_for(self, topic: TopicDigest) -> str:
+        existing = self._skill_dir_names.get(topic.slug)
+        if existing is not None:
+            return existing
+        base_name = _normalize_skill_dir_name(topic.slug)
+        candidate = base_name
+        suffix = 2
+        while candidate in self._used_skill_dir_names:
+            candidate = "{base}-{suffix}".format(base=base_name, suffix=suffix)
+            suffix += 1
+        self._used_skill_dir_names.add(candidate)
+        self._skill_dir_names[topic.slug] = candidate
+        return candidate
+
     def write_topics(
         self,
         topics: Sequence[TopicDigest],
@@ -110,12 +134,22 @@ class MarkdownArtifactWriter:
         reporter = progress_reporter or NoOpProgressReporter()
         output_dir.mkdir(parents=True, exist_ok=True)
         artifact_paths: Dict[str, Path] = {}
-        for topic in topics:
-            topic_path = output_dir / "{slug}.md".format(slug=topic.slug)
-            reporter.update("Writing {name}.".format(name=file_label(topic_path)))
-            topic_path.write_text(_render_topic_markdown(topic), encoding="utf-8")
-            artifact_paths[topic.slug] = topic_path
-            reporter.persist("Generated {path}.".format(path=topic_path))
+        for layout in self.agent_layouts:
+            agent_root = output_dir / layout.agent_name
+            skills_root = agent_root.joinpath(*layout.skills_path_parts)
+            skills_root.mkdir(parents=True, exist_ok=True)
+            artifact_paths[layout.agent_name] = agent_root
+            for topic in topics:
+                skill_dir_name = self._skill_dir_name_for(topic)
+                skill_path = skills_root / skill_dir_name / "SKILL.md"
+                skill_path.parent.mkdir(parents=True, exist_ok=True)
+                reporter.update("Writing {name}.".format(name=file_label(skill_path)))
+                skill_path.write_text(
+                    _render_skill_markdown(topic, layout, skill_dir_name),
+                    encoding="utf-8",
+                )
+                artifact_paths["{agent}:{slug}".format(agent=layout.agent_name, slug=topic.slug)] = skill_path
+                reporter.persist("Generated {path}.".format(path=skill_path))
         return artifact_paths
 
     def write_index(
@@ -124,13 +158,10 @@ class MarkdownArtifactWriter:
         output_dir: Path,
         progress_reporter: Optional[ProgressReporter] = None,
     ) -> Path:
-        reporter = progress_reporter or NoOpProgressReporter()
+        del result
+        del progress_reporter
         output_dir.mkdir(parents=True, exist_ok=True)
-        index_path = output_dir / "INDEX.md"
-        reporter.update("Writing {name}.".format(name=file_label(index_path)))
-        index_path.write_text(_render_index_markdown(result), encoding="utf-8")
-        reporter.persist("Generated {path}.".format(path=index_path))
-        return index_path
+        return output_dir
 
     def write(
         self,
@@ -142,11 +173,6 @@ class MarkdownArtifactWriter:
         reporter.persist("Writing artifacts to {path}.".format(path=output_dir))
         artifact_paths = self.write_topics(
             result.topics,
-            output_dir,
-            progress_reporter=reporter,
-        )
-        artifact_paths["INDEX"] = self.write_index(
-            result,
             output_dir,
             progress_reporter=reporter,
         )

--- a/src/digester/core/prompts.py
+++ b/src/digester/core/prompts.py
@@ -16,7 +16,7 @@ def build_digest_system_prompt() -> str:
         "Return strict JSON with keys: topic_updates, should_continue, rationale. "
         "Each topic update must include slug, title, summary, key_points, references. "
         "references must contain source_id, source_path, locator. "
-        "Treat each topic like a section-level skill file that another agent could route to from an INDEX.md and reuse on its own. "
+        "Treat each topic like a section-level skill file that another agent could discover from a SKILL.md description and reuse on its own. "
         "Write summaries as routing-friendly purpose statements: what task the skill helps with, what context it preserves, and when an agent should load it. "
         "Write key_points as actionable instructions, constraints, workflow steps, commands, checks, or caveats, not vague observations. "
         "Set should_continue to false only when the current visible topics already have strong coverage and the next chunks are more likely to introduce different topics than extend these ones."

--- a/src/digester/interfaces/api.py
+++ b/src/digester/interfaces/api.py
@@ -53,11 +53,6 @@ class DocumentDigester:
             config=self.config,
             progress_reporter=self.progress_reporter,
         ).run(documents, on_topics_finalized=write_completed_topics)
-        artifact_paths["INDEX"] = self.artifact_writer.write_index(
-            result,
-            output_path,
-            progress_reporter=self.progress_reporter,
-        )
         result.artifact_paths = artifact_paths
         self.progress_reporter.persist(
             "Finished digestion with {count} skill file(s).".format(count=len(result.topics))

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -141,9 +141,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             progress_reporter=reporter,
         )
         result = digester.digest_paths(args.inputs, args.output_dir)
+        agent_targets = len([key for key in result.artifact_paths if ":" not in key])
         print(
-            "Wrote {count} skill files plus INDEX.md to {output_dir}".format(
+            "Wrote {count} skill(s) for {agents} agent target(s) to {output_dir}".format(
                 count=len(result.topics),
+                agents=agent_targets,
                 output_dir=args.output_dir,
             )
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,8 +54,10 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "Wrote 1 skill files plus INDEX.md" in captured.out
-    assert (output_dir / "summary.md").exists()
+    assert "Wrote 1 skill(s) for 3 agent target(s)" in captured.out
+    assert (output_dir / "copilot" / ".github" / "skills" / "summary" / "SKILL.md").exists()
+    assert (output_dir / "opencode" / ".opencode" / "skills" / "summary" / "SKILL.md").exists()
+    assert (output_dir / "codex" / ".agents" / "skills" / "summary" / "SKILL.md").exists()
     assert "Using provider openai with model fake-model." in captured.err
     assert "Loaded notes.txt with 1 section(s)." in captured.err
     assert "Completed batch 1/1; tracking 1 topic(s)." in captured.err

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -71,20 +71,29 @@ def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
         progress_reporter=reporter,
     ).digest_paths([input_path], output_dir)
 
-    topic_text = (output_dir / "architecture.md").read_text(encoding="utf-8")
-    index_text = (output_dir / "INDEX.md").read_text(encoding="utf-8")
+    copilot_skill = output_dir / "copilot" / ".github" / "skills" / "architecture" / "SKILL.md"
+    opencode_skill = output_dir / "opencode" / ".opencode" / "skills" / "architecture" / "SKILL.md"
+    codex_skill = output_dir / "codex" / ".agents" / "skills" / "architecture" / "SKILL.md"
+    topic_text = copilot_skill.read_text(encoding="utf-8")
+    opencode_text = opencode_skill.read_text(encoding="utf-8")
 
-    assert (output_dir / "architecture.md").exists()
-    assert (output_dir / "INDEX.md").exists()
-    assert "Architecture" in index_text
-    assert "## Skill Routing" in index_text
-    assert "Use [Architecture](architecture.md) when the task involves:" in index_text
+    assert copilot_skill.exists()
+    assert opencode_skill.exists()
+    assert codex_skill.exists()
+    assert not (output_dir / "INDEX.md").exists()
+    assert 'name: architecture' in topic_text
+    assert 'description: "Use this skill when work requires Summarizes the system design and interfaces."' in topic_text
     assert "## When To Use" in topic_text
     assert "## Purpose" in topic_text
     assert "## Core Instructions" in topic_text
     assert "## Workflow Notes" in topic_text
     assert "## Source files" in topic_text
+    assert "compatibility: opencode" in opencode_text
     assert result.stop_reason == "Processed all available chunks."
+    assert result.artifact_paths["copilot"] == output_dir / "copilot"
+    assert result.artifact_paths["copilot:architecture"] == copilot_skill
+    assert result.artifact_paths["opencode:architecture"] == opencode_skill
+    assert result.artifact_paths["codex:architecture"] == codex_skill
     assert provider.calls == 3
     persisted = [message for kind, message in reporter.messages if kind == "persist"]
     assert any("Loaded source.txt with 1 section(s)." == message for message in persisted)
@@ -92,7 +101,7 @@ def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
     assert any("Completed batch 3/3; tracking 1 topic(s)." == message for message in persisted)
     assert any("marked the current topic cluster as complete" in message for message in persisted)
     assert any("Finished digestion with 1 skill file(s)." == message for message in persisted)
-    assert any("Generated " in message and "architecture.md" in message for message in persisted)
+    assert any("Generated " in message and "copilot/.github/skills/architecture/SKILL.md" in message for message in persisted)
 
 
 class ManyTopicProvider(LLMProvider):
@@ -129,9 +138,10 @@ def test_document_digester_keeps_all_discovered_topics_for_export(tmp_path: Path
 
     assert len(result.topics) == 3
     assert [topic.slug for topic in result.topics] == ["skill-1", "skill-2", "skill-3"]
-    assert (output_dir / "skill-1.md").exists()
-    assert (output_dir / "skill-2.md").exists()
-    assert (output_dir / "skill-3.md").exists()
+    for slug in ("skill-1", "skill-2", "skill-3"):
+        assert (output_dir / "copilot" / ".github" / "skills" / slug / "SKILL.md").exists()
+        assert (output_dir / "opencode" / ".opencode" / "skills" / slug / "SKILL.md").exists()
+        assert (output_dir / "codex" / ".agents" / "skills" / slug / "SKILL.md").exists()
 
 
 class LimitedBatchProvider(LLMProvider):
@@ -194,16 +204,12 @@ class FinalizeEachBatchProvider(LLMProvider):
 
 class RecordingArtifactWriter(MarkdownArtifactWriter):
     def __init__(self) -> None:
+        super().__init__()
         self.topic_batches: List[List[str]] = []
-        self.index_writes = 0
 
     def write_topics(self, topics, output_dir, progress_reporter=None):
         self.topic_batches.append([topic.slug for topic in topics])
         return super().write_topics(topics, output_dir, progress_reporter)
-
-    def write_index(self, result, output_dir, progress_reporter=None):
-        self.index_writes += 1
-        return super().write_index(result, output_dir, progress_reporter)
 
 
 def test_document_digester_flushes_completed_topics_incrementally(tmp_path: Path) -> None:
@@ -224,8 +230,7 @@ def test_document_digester_flushes_completed_topics_incrementally(tmp_path: Path
 
     assert provider.finalize_calls == [["topic-1"], ["topic-2"], ["topic-3"]]
     assert writer.topic_batches == [["topic-1"], ["topic-2"], ["topic-3"]]
-    assert writer.index_writes == 1
     assert [topic.slug for topic in result.topics] == ["topic-1", "topic-2", "topic-3"]
-    assert (output_dir / "topic-1.md").exists()
-    assert (output_dir / "topic-2.md").exists()
-    assert (output_dir / "topic-3.md").exists()
+    assert (output_dir / "copilot" / ".github" / "skills" / "topic-1" / "SKILL.md").exists()
+    assert (output_dir / "copilot" / ".github" / "skills" / "topic-2" / "SKILL.md").exists()
+    assert (output_dir / "copilot" / ".github" / "skills" / "topic-3" / "SKILL.md").exists()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -35,7 +35,7 @@ def test_digest_prompts_preserve_setup_and_hardware_detail() -> None:
     assert "hardware installation steps" in system_prompt
     assert "section-level skill file" in system_prompt
     assert "Codex, Claude Code, and Copilot" in system_prompt
-    assert "INDEX.md" in system_prompt
+    assert "SKILL.md description" in system_prompt
     assert "routing-friendly purpose statements" in system_prompt
     assert "setup sequences" in user_prompt
     assert "verification steps" in user_prompt


### PR DESCRIPTION
## Summary
- export finalized topics as agent-native `SKILL.md` trees for Copilot, OpenCode, and Codex
- replace the flat runtime `INDEX.md` output path with per-agent skill routing via frontmatter descriptions
- update CLI/API reporting, tests, and docs to match the new multi-directory artifact contract

## Testing
- PYTHONPATH=src .venv/bin/pytest -q