### PR TITLE
Add MockLLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ out/
 - `openai`: hosted OpenAI models
 - `openai-compatible`: local or self-hosted models that expose an OpenAI-compatible API
 - `ollama`: local Ollama server via `http://<host>:<port>/api/chat`
+- `mock-llm`: deterministic fake output for fast end-to-end validation without a real LLM call
 
 ## CLI example
 
@@ -61,6 +62,17 @@ bookworm digest docs/*.txt \
 ```
 
 If `--ollama-port` is omitted, the CLI defaults to port `11434`.
+
+## MockLLM example
+
+```bash
+bookworm digest docs/*.txt \
+  --output-dir out \
+  --provider-kind mock-llm \
+  --model fake-model
+```
+
+`mock-llm` does not require an API key and intentionally produces synthetic placeholder topics from source metadata so you can validate ingestion, orchestration, and artifact export flows quickly.
 
 ## Loop semantics
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -231,6 +231,12 @@ When `--provider-kind ollama` is selected, the CLI must:
 - default the port to `11434`
 - allow both values to be overridden explicitly
 
+When `--provider-kind mock-llm` is selected, the CLI must:
+
+- require no API key
+- require no network access
+- return deterministic placeholder topics that preserve real source references for end-to-end validation
+
 ## 11. Library API Requirements
 
 The library API must:

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -34,6 +34,7 @@ bookworm/
 │       ├── providers/
 │       │   ├── base.py
 │       │   ├── factory.py
+│       │   ├── mock_llm_provider.py
 │       │   ├── openai_compatible.py
 │       │   └── openai_provider.py
 │       └── sources/
@@ -53,7 +54,7 @@ bookworm/
 | --- | --- |
 | `digester.core` | Canonical data model, chunking rules, prompt construction, orchestration, markdown writing |
 | `digester.sources` | File-type-specific extraction and normalization into `SourceDocument` |
-| `digester.providers` | Provider abstraction and concrete OpenAI, OpenAI-compatible, and Ollama LLM transports |
+| `digester.providers` | Provider abstraction and concrete OpenAI, OpenAI-compatible, Ollama, and MockLLM transports |
 | `digester.interfaces` | Public library API and CLI |
 | `tests` | Behavioral coverage for adapters, chunking, pipeline, and CLI |
 
@@ -411,6 +412,7 @@ This makes local-model development straightforward without forcing users through
 - `openai`
 - `openai-compatible`
 - `ollama`
+- `mock-llm`
 
 ## 10. Artifact Generation
 
@@ -499,6 +501,8 @@ Provider-specific parameters:
 - `--organization`
 - `--ollama-host`
 - `--ollama-port`
+
+`mock-llm` skips network access and credentials entirely, returning deterministic placeholder topics derived from source metadata and references so the rest of the digestion pipeline can be exercised quickly.
 
 ## 12. Error Handling
 

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -21,7 +21,7 @@ def build_parser() -> argparse.ArgumentParser:
     digest_parser.add_argument(
         "--provider-kind",
         default="openai",
-        choices=["openai", "openai-compatible", "ollama"],
+        choices=["openai", "openai-compatible", "ollama", "mock-llm"],
         help="LLM provider kind.",
     )
     digest_parser.add_argument("--model", required=True, help="Model name to invoke.")
@@ -93,7 +93,7 @@ def _read_api_key_file(path_value: str) -> str:
 
 
 def _resolve_api_key(args: argparse.Namespace) -> str:
-    if args.provider_kind == "ollama":
+    if args.provider_kind in {"ollama", "mock-llm"}:
         return ""
     if args.api_key_file:
         return _read_api_key_file(args.api_key_file)

--- a/src/digester/providers/__init__.py
+++ b/src/digester/providers/__init__.py
@@ -1,11 +1,13 @@
 from .base import LLMProvider
 from .factory import ProviderSettings, create_provider
+from .mock_llm_provider import MockLLMProvider
 from .ollama_provider import OllamaProvider
 from .openai_compatible import OpenAICompatibleProvider
 from .openai_provider import OpenAIProvider
 
 __all__ = [
     "LLMProvider",
+    "MockLLMProvider",
     "OllamaProvider",
     "OpenAICompatibleProvider",
     "OpenAIProvider",

--- a/src/digester/providers/factory.py
+++ b/src/digester/providers/factory.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from .base import LLMProvider
+from .mock_llm_provider import MockLLMProvider
 from .ollama_provider import OllamaProvider
 from .openai_compatible import OpenAICompatibleProvider
 from .openai_provider import OpenAIProvider
@@ -39,4 +40,6 @@ def create_provider(settings: ProviderSettings) -> LLMProvider:
             host=settings.ollama_host,
             port=settings.ollama_port,
         )
+    if settings.provider_kind == "mock-llm":
+        return MockLLMProvider(model=settings.model)
     raise ValueError("Unknown provider kind: {kind}".format(kind=settings.provider_kind))

--- a/src/digester/providers/mock_llm_provider.py
+++ b/src/digester/providers/mock_llm_provider.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import re
+from pathlib import PurePath
+from typing import Dict, List, Set, Tuple
+
+from ..core.models import DigestBatchRequest, DigestDecision, SourceRef, TopicDigest
+from .base import LLMProvider
+
+
+def _slugify(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    normalized = re.sub(r"-{2,}", "-", normalized)
+    return normalized or "mock-topic"
+
+
+def _source_label(source_id: str, source_path: str) -> str:
+    stem = PurePath(source_path).stem.strip()
+    if stem:
+        return stem.replace("-", " ").replace("_", " ")
+    return source_id.replace("-", " ").replace("_", " ")
+
+
+def _titleize(value: str) -> str:
+    return " ".join(part.capitalize() for part in value.split())
+
+
+class MockLLMProvider(LLMProvider):
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+    def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
+        if not request.chunk_batch:
+            return DigestDecision(
+                topic_updates=[],
+                should_continue=False,
+                rationale="MockLLM received an empty batch.",
+            )
+
+        grouped_refs: Dict[Tuple[str, str], List[SourceRef]] = {}
+        grouped_seen: Dict[Tuple[str, str], Set[Tuple[str, str, str]]] = {}
+        for chunk in request.chunk_batch:
+            key = (chunk.source_id, chunk.source_path)
+            refs = grouped_refs.setdefault(key, [])
+            seen = grouped_seen.setdefault(key, set())
+            ref_key = (
+                chunk.source_ref.source_id,
+                chunk.source_ref.source_path,
+                chunk.source_ref.locator,
+            )
+            if ref_key in seen:
+                continue
+            seen.add(ref_key)
+            refs.append(chunk.source_ref)
+
+        topic_updates: List[TopicDigest] = []
+        for source_id, source_path in grouped_refs:
+            label = _source_label(source_id=source_id, source_path=source_path)
+            topic_updates.append(
+                TopicDigest(
+                    slug="mock-{source_id}".format(source_id=_slugify(source_id)),
+                    title="Mock {label}".format(label=_titleize(label)),
+                    summary=(
+                        "end-to-end validation for {label} without a real LLM response.\n\n"
+                        "MockLLM generated this placeholder from source metadata and preserved "
+                        "references without semantically parsing the document content."
+                    ).format(label=label),
+                    key_points=[
+                        "Treat this topic as synthetic fixture output for ingestion, orchestration, and artifact export checks.",
+                        "MockLLM keeps real source references so downstream skills still point at the original files.",
+                        "Switch to a real provider before using generated summaries for implementation or product decisions.",
+                    ],
+                    references=grouped_refs[(source_id, source_path)],
+                )
+            )
+
+        should_continue = request.batch_number < request.total_batches
+        rationale = (
+            "MockLLM continues through the remaining batches to exercise the full pipeline."
+            if should_continue
+            else "MockLLM reached the final batch and finalized the placeholder topics."
+        )
+        return DigestDecision(
+            topic_updates=topic_updates,
+            should_continue=should_continue,
+            rationale=rationale,
+        )
+
+    def finalize_topics(self, topics: List[TopicDigest]) -> List[TopicDigest]:
+        return sorted(topics, key=lambda topic: topic.slug)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,6 +222,34 @@ def test_cli_passes_ollama_host_and_port(monkeypatch, tmp_path: Path, capsys) ->
     assert "Using provider ollama (192.168.1.10:11555) with model llama3.1." in captured.err
 
 
+def test_cli_mock_llm_runs_without_api_key(tmp_path: Path, monkeypatch, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert (output_dir / "copilot" / ".github" / "skills" / "mock-notes" / "SKILL.md").exists()
+    assert (output_dir / "opencode" / ".opencode" / "skills" / "mock-notes" / "SKILL.md").exists()
+    assert (output_dir / "codex" / ".agents" / "skills" / "mock-notes" / "SKILL.md").exists()
+    assert "Using provider mock-llm with model fake-model." in captured.err
+    assert "Wrote 1 skill(s) for 3 agent target(s)" in captured.out
+
+
 def test_cli_max_topics_flag_is_kept_as_compatibility_alias() -> None:
     args = cli.build_parser().parse_args(
         [
@@ -231,6 +259,8 @@ def test_cli_max_topics_flag_is_kept_as_compatibility_alias() -> None:
             "artifacts",
             "--model",
             "fake-model",
+            "--provider-kind",
+            "mock-llm",
             "--max-topics",
             "7",
         ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -6,10 +6,28 @@ import httpx
 import pytest
 from openai import PermissionDeniedError
 
-from digester.core.models import DigestBatchRequest, DigestConfig, SourceRef, TopicDigest
-from digester.providers import ProviderSettings, create_provider
+from digester.core.models import (
+    ContentChunk,
+    DigestBatchRequest,
+    DigestConfig,
+    SourceRef,
+    TopicDigest,
+)
+from digester.providers import MockLLMProvider, ProviderSettings, create_provider
 from digester.providers.ollama_provider import OllamaProvider, _normalize_base_url
 from digester.providers.openai_provider import OpenAIProvider
+
+
+def test_create_provider_builds_mock_llm_provider() -> None:
+    provider = create_provider(
+        ProviderSettings(
+            provider_kind="mock-llm",
+            model="fake-model",
+        )
+    )
+
+    assert isinstance(provider, MockLLMProvider)
+    assert provider.model == "fake-model"
 
 
 def test_create_provider_builds_ollama_provider() -> None:
@@ -30,6 +48,58 @@ def test_normalize_base_url_preserves_scheme_and_default_port() -> None:
     assert _normalize_base_url("127.0.0.1", 11434) == "http://127.0.0.1:11434"
     assert _normalize_base_url("http://10.0.0.8", 11434) == "http://10.0.0.8:11434"
     assert _normalize_base_url("https://localhost:15000", 11434) == "https://localhost:15000"
+
+
+def test_mock_llm_provider_generates_deterministic_placeholder_topics() -> None:
+    provider = MockLLMProvider(model="fake-model")
+
+    decision = provider.digest_batch(
+        DigestBatchRequest(
+            config=DigestConfig(),
+            batch_number=1,
+            total_batches=2,
+            chunk_batch=[
+                ContentChunk(
+                    chunk_id="alpha-chunk-1",
+                    source_id="alpha-notes",
+                    source_path="/tmp/Alpha Notes.txt",
+                    section_heading="Alpha Notes",
+                    text="Alpha content",
+                    source_ref=SourceRef(
+                        source_id="alpha-notes",
+                        source_path="/tmp/Alpha Notes.txt",
+                        locator="full-document",
+                    ),
+                ),
+                ContentChunk(
+                    chunk_id="beta-chunk-1",
+                    source_id="beta-notes",
+                    source_path="/tmp/beta_notes.md",
+                    section_heading="beta_notes",
+                    text="Beta content",
+                    source_ref=SourceRef(
+                        source_id="beta-notes",
+                        source_path="/tmp/beta_notes.md",
+                        locator="full-document",
+                    ),
+                ),
+            ],
+            current_topics=[],
+        )
+    )
+
+    assert decision.should_continue is True
+    assert (
+        decision.rationale
+        == "MockLLM continues through the remaining batches to exercise the full pipeline."
+    )
+    assert [topic.slug for topic in decision.topic_updates] == ["mock-alpha-notes", "mock-beta-notes"]
+    assert [topic.title for topic in decision.topic_updates] == ["Mock Alpha Notes", "Mock Beta Notes"]
+    assert all(
+        "without semantically parsing the document content" in topic.summary
+        for topic in decision.topic_updates
+    )
+    assert all(topic.references for topic in decision.topic_updates)
 
 
 def test_ollama_provider_digest_batch(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add a deterministic `MockLLMProvider` that returns synthetic topic digests from source metadata and references without a live model call
- wire `mock-llm` into provider selection and CLI credential handling so it can run end to end without API keys
- document the new provider kind and cover it with provider plus CLI tests

## Testing
- PYTHONPATH=src .venv/bin/pytest -q