### PR TITLE
Fix mock-llm skill exports

### DIFF
--- a/src/digester/providers/mock_llm_provider.py
+++ b/src/digester/providers/mock_llm_provider.py
@@ -28,6 +28,25 @@ def _titleize(value: str) -> str:
 class MockLLMProvider(LLMProvider):
     def __init__(self, model: str) -> None:
         self.model = model
+        self._topic_slugs_by_source: Dict[Tuple[str, str], str] = {}
+        self._used_topic_slugs: Set[str] = set()
+
+    def _topic_slug_for(self, source_id: str, source_path: str) -> str:
+        key = (source_id, source_path)
+        existing = self._topic_slugs_by_source.get(key)
+        if existing is not None:
+            return existing
+
+        base_slug = "mock-{source_id}".format(source_id=_slugify(source_id))
+        candidate = base_slug
+        suffix = 2
+        while candidate in self._used_topic_slugs:
+            candidate = "{base_slug}-{suffix}".format(base_slug=base_slug, suffix=suffix)
+            suffix += 1
+
+        self._used_topic_slugs.add(candidate)
+        self._topic_slugs_by_source[key] = candidate
+        return candidate
 
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
         if not request.chunk_batch:
@@ -58,7 +77,7 @@ class MockLLMProvider(LLMProvider):
             label = _source_label(source_id=source_id, source_path=source_path)
             topic_updates.append(
                 TopicDigest(
-                    slug="mock-{source_id}".format(source_id=_slugify(source_id)),
+                    slug=self._topic_slug_for(source_id=source_id, source_path=source_path),
                     title="Mock {label}".format(label=_titleize(label)),
                     summary=(
                         "end-to-end validation for {label} without a real LLM response.\n\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,8 @@ def test_cli_mock_llm_runs_without_api_key(tmp_path: Path, monkeypatch, capsys) 
             "mock-llm",
             "--model",
             "fake-model",
+            "--batch-size",
+            "1",
         ]
     )
 
@@ -248,6 +250,43 @@ def test_cli_mock_llm_runs_without_api_key(tmp_path: Path, monkeypatch, capsys) 
     assert (output_dir / "codex" / ".agents" / "skills" / "mock-notes" / "SKILL.md").exists()
     assert "Using provider mock-llm with model fake-model." in captured.err
     assert "Wrote 1 skill(s) for 3 agent target(s)" in captured.out
+
+
+def test_cli_mock_llm_writes_distinct_skills_for_duplicate_source_stems(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_input = first_dir / "notes.txt"
+    second_input = second_dir / "notes.txt"
+    first_input.write_text("Alpha content.", encoding="utf-8")
+    second_input.write_text("Beta content.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(first_input),
+            str(second_input),
+            "--output-dir",
+            str(output_dir),
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    for slug in ("mock-notes", "mock-notes-2"):
+        assert (output_dir / "copilot" / ".github" / "skills" / slug / "SKILL.md").exists()
+        assert (output_dir / "opencode" / ".opencode" / "skills" / slug / "SKILL.md").exists()
+        assert (output_dir / "codex" / ".agents" / "skills" / slug / "SKILL.md").exists()
+    assert "Wrote 2 skill(s) for 3 agent target(s)" in captured.out
 
 
 def test_cli_max_topics_flag_is_kept_as_compatibility_alias() -> None:


### PR DESCRIPTION
## Summary
- keep mock-llm topic slugs unique per source path so duplicate file stems do not collapse into one exported skill
- preserve the existing simple mock-<source> naming when there is no collision
- add a CLI regression test covering duplicate source stems writing into all agent skill folders

## Testing
- PYTHONPATH=src .venv/bin/pytest -q