### PR TITLE
Add verbose LLM request diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ bookworm digest docs/*.txt \
   --provider-kind ollama \
   --model llama3.1 \
   --ollama-host 127.0.0.1 \
-  --ollama-port 11434
+  --ollama-port 11434 \
+  --verbose
 ```
 
 If `--ollama-port` is omitted, the CLI defaults to port `11434`.
+Use `--verbose` or `-v` to print truncated LLM request and response previews, total character counts, and round-trip timing for each model call.
 
 ## MockLLM example
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ bookworm digest docs/*.txt \
 
 If `--ollama-port` is omitted, the CLI defaults to port `11434`.
 Use `--verbose` or `-v` to print truncated LLM request and response previews, total character counts, and round-trip timing for each model call.
+Use `--vv` to log the full escaped request and response bodies without omitting the middle.
+Use `--log-location stdio|/path/to/bookworm.log` to keep logs on stdio or write them to a file. The default is `stdio`.
 
 ## MockLLM example
 

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -56,6 +56,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Port for the local Ollama server.",
     )
     digest_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print verbose LLM request and response diagnostics.",
+    )
+    digest_parser.add_argument(
         "--timeout-sc",
         type=int,
         default=None,
@@ -120,7 +126,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command != "digest":
         parser.error("Unknown command.")
 
-    reporter = ConsoleProgressReporter()
+    reporter = ConsoleProgressReporter(verbose=args.verbose)
     try:
         reporter.persist(_provider_message(args))
         provider = create_provider(
@@ -135,6 +141,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 timeout_seconds=args.timeout_sc,
             )
         )
+        provider.set_progress_reporter(reporter)
         provider.validate_configuration()
         digester = DocumentDigester(
             provider=provider,

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, TextIO, Tuple
 
 from ..core import DigestConfig
 from ..providers import ProviderSettings, create_provider
@@ -55,11 +56,23 @@ def build_parser() -> argparse.ArgumentParser:
         default=int(os.getenv("OLLAMA_PORT", "11434")),
         help="Port for the local Ollama server.",
     )
-    digest_parser.add_argument(
+    verbose_group = digest_parser.add_mutually_exclusive_group()
+    verbose_group.add_argument(
         "--verbose",
         "-v",
         action="store_true",
-        help="Print verbose LLM request and response diagnostics.",
+        help="Print truncated LLM request and response diagnostics.",
+    )
+    verbose_group.add_argument(
+        "--vv",
+        action="store_true",
+        help="Print full LLM request and response diagnostics without omitting the middle.",
+    )
+    digest_parser.add_argument(
+        "--log-location",
+        default="stdio",
+        metavar="stdio|file_path",
+        help="Write progress and verbose logs to stdio or to the specified file path.",
     )
     digest_parser.add_argument(
         "--timeout-sc",
@@ -104,6 +117,34 @@ def _read_api_key_file(path_value: str) -> str:
     return api_key
 
 
+def _resolve_verbose_level(args: argparse.Namespace) -> int:
+    if args.vv:
+        return 2
+    if args.verbose:
+        return 1
+    return 0
+
+
+def _build_reporter(args: argparse.Namespace) -> Tuple[ConsoleProgressReporter, Optional[TextIO]]:
+    verbose_level = _resolve_verbose_level(args)
+    if args.log_location == "stdio":
+        return ConsoleProgressReporter(verbose_level=verbose_level), None
+    log_path = Path(args.log_location).expanduser()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        stream = log_path.open("w", encoding="utf-8")
+    except OSError as error:
+        raise ValueError("Unable to open log file {path}: {error}".format(path=log_path, error=error)) from error
+    return (
+        ConsoleProgressReporter(
+            stream=stream,
+            verbose_level=verbose_level,
+            rewrite_updates=False,
+        ),
+        stream,
+    )
+
+
 def _resolve_api_key(args: argparse.Namespace) -> str:
     if args.provider_kind in {"ollama", "mock-llm"}:
         return ""
@@ -126,7 +167,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command != "digest":
         parser.error("Unknown command.")
 
-    reporter = ConsoleProgressReporter(verbose=args.verbose)
+    log_stream = None
+    try:
+        reporter, log_stream = _build_reporter(args)
+    except ValueError as error:
+        ConsoleProgressReporter().persist("Error: {message}".format(message=error))
+        return 1
     try:
         reporter.persist(_provider_message(args))
         provider = create_provider(
@@ -168,3 +214,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         reporter.clear()
         reporter.persist("Error: {message}".format(message=error))
         return 1
+    finally:
+        if log_stream is not None:
+            log_stream.close()

--- a/src/digester/providers/base.py
+++ b/src/digester/providers/base.py
@@ -1,12 +1,92 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from ..core.models import DigestBatchRequest, DigestDecision, TopicDigest
+from ..utils.progress import NoOpProgressReporter, ProgressReporter
+
+
+def _escaped_preview(text: str, head_chars: int = 160, tail_chars: int = 80) -> str:
+    escaped = (
+        text.replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+    if len(text) <= head_chars + tail_chars:
+        return escaped
+    head = (
+        text[:head_chars]
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+    tail = (
+        text[-tail_chars:]
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+    omitted = len(text) - head_chars - tail_chars
+    return "{head}...[omitted {omitted} chars]...{tail}".format(
+        head=head,
+        omitted=omitted,
+        tail=tail,
+    )
 
 
 class LLMProvider(ABC):
+    def __init__(self, progress_reporter: Optional[ProgressReporter] = None) -> None:
+        self.progress_reporter = progress_reporter or NoOpProgressReporter()
+
+    def set_progress_reporter(self, progress_reporter: Optional[ProgressReporter]) -> None:
+        self.progress_reporter = progress_reporter or NoOpProgressReporter()
+
+    def _log_request(self, provider_name: str, model: str, system_prompt: str, user_prompt: str) -> None:
+        system_chars = len(system_prompt)
+        user_chars = len(user_prompt)
+        total_chars = system_chars + user_chars
+        self.progress_reporter.verbose(
+            "Verbose: sending {total} chars to {provider} model {model} "
+            "(system={system}, user={user}).".format(
+                total=total_chars,
+                provider=provider_name,
+                model=model,
+                system=system_chars,
+                user=user_chars,
+            )
+        )
+        self.progress_reporter.verbose(
+            'Verbose: request preview: system="{system}" user="{user}"'.format(
+                system=_escaped_preview(system_prompt),
+                user=_escaped_preview(user_prompt),
+            )
+        )
+
+    def _log_response(
+        self,
+        provider_name: str,
+        model: str,
+        response_text: str,
+        elapsed_seconds: float,
+    ) -> None:
+        self.progress_reporter.verbose(
+            "Verbose: {provider} model {model} returned {count} chars in {elapsed:.2f}s.".format(
+                provider=provider_name,
+                model=model,
+                count=len(response_text),
+                elapsed=elapsed_seconds,
+            )
+        )
+        self.progress_reporter.verbose(
+            'Verbose: response preview: "{preview}"'.format(
+                preview=_escaped_preview(response_text),
+            )
+        )
+
     def validate_configuration(self) -> None:
         return None
 

--- a/src/digester/providers/base.py
+++ b/src/digester/providers/base.py
@@ -48,6 +48,10 @@ def _escaped_fragment(text: str) -> str:
     )
 
 
+def _escaped_full_text(text: str) -> str:
+    return _escaped_fragment(text)
+
+
 def _json_error_excerpt(text: str, position: int, radius: int = 80) -> str:
     start = max(position - radius, 0)
     end = min(position + radius, len(text))
@@ -77,6 +81,22 @@ class LLMProvider(ABC):
     def set_progress_reporter(self, progress_reporter: Optional[ProgressReporter]) -> None:
         self.progress_reporter = progress_reporter or NoOpProgressReporter()
 
+    def _verbosity_level(self) -> int:
+        verbosity = getattr(self.progress_reporter, "verbosity", None)
+        if callable(verbosity):
+            return int(verbosity())
+        return 0
+
+    def _format_verbose_text(self, text: str) -> str:
+        if self._verbosity_level() >= 2:
+            return _escaped_full_text(text)
+        return _escaped_preview(text)
+
+    def _verbose_text_label(self) -> str:
+        if self._verbosity_level() >= 2:
+            return "body"
+        return "preview"
+
     def _log_request(self, provider_name: str, model: str, system_prompt: str, user_prompt: str) -> None:
         system_chars = len(system_prompt)
         user_chars = len(user_prompt)
@@ -92,9 +112,10 @@ class LLMProvider(ABC):
             )
         )
         self.progress_reporter.verbose(
-            'Verbose: request preview: system="{system}" user="{user}"'.format(
-                system=_escaped_preview(system_prompt),
-                user=_escaped_preview(user_prompt),
+            'Verbose: request {label}: system="{system}" user="{user}"'.format(
+                label=self._verbose_text_label(),
+                system=self._format_verbose_text(system_prompt),
+                user=self._format_verbose_text(user_prompt),
             )
         )
 
@@ -114,8 +135,9 @@ class LLMProvider(ABC):
             )
         )
         self.progress_reporter.verbose(
-            'Verbose: response preview: "{preview}"'.format(
-                preview=_escaped_preview(response_text),
+            'Verbose: response {label}: "{preview}"'.format(
+                label=self._verbose_text_label(),
+                preview=self._format_verbose_text(response_text),
             )
         )
 

--- a/src/digester/providers/base.py
+++ b/src/digester/providers/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
@@ -35,6 +36,37 @@ def _escaped_preview(text: str, head_chars: int = 160, tail_chars: int = 80) -> 
         head=head,
         omitted=omitted,
         tail=tail,
+    )
+
+
+def _escaped_fragment(text: str) -> str:
+    return (
+        text.replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+
+
+def _json_error_excerpt(text: str, position: int, radius: int = 80) -> str:
+    start = max(position - radius, 0)
+    end = min(position + radius, len(text))
+    before = _escaped_fragment(text[start:position])
+    current = text[position : position + 1]
+    after = _escaped_fragment(text[position + 1 : end])
+    marker = "<EOF>" if not current else _escaped_fragment(current)
+    prefix = ""
+    suffix = ""
+    if start > 0:
+        prefix = "...[{count} chars omitted]...".format(count=start)
+    if end < len(text):
+        suffix = "...[{count} chars omitted]...".format(count=len(text) - end)
+    return '{prefix}{before}<<<HERE>>>{marker}<<<HERE>>>{after}{suffix}'.format(
+        prefix=prefix,
+        before=before,
+        marker=marker,
+        after=after,
+        suffix=suffix,
     )
 
 
@@ -86,6 +118,29 @@ class LLMProvider(ABC):
                 preview=_escaped_preview(response_text),
             )
         )
+
+    def _parse_json_response(
+        self,
+        provider_name: str,
+        model: str,
+        response_text: str,
+        payload_label: str = "model response",
+    ) -> object:
+        try:
+            return json.loads(response_text)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                "{provider} model {model} returned invalid JSON in the {payload}: {detail}. "
+                "Received {count} chars. Around char {position}: \"{excerpt}\"".format(
+                    provider=provider_name,
+                    model=model,
+                    payload=payload_label,
+                    detail=error,
+                    count=len(response_text),
+                    position=error.pos,
+                    excerpt=_json_error_excerpt(response_text, error.pos),
+                )
+            ) from error
 
     def validate_configuration(self) -> None:
         return None

--- a/src/digester/providers/mock_llm_provider.py
+++ b/src/digester/providers/mock_llm_provider.py
@@ -27,6 +27,7 @@ def _titleize(value: str) -> str:
 
 class MockLLMProvider(LLMProvider):
     def __init__(self, model: str) -> None:
+        super().__init__()
         self.model = model
         self._topic_slugs_by_source: Dict[Tuple[str, str], str] = {}
         self._used_topic_slugs: Set[str] = set()

--- a/src/digester/providers/ollama_provider.py
+++ b/src/digester/providers/ollama_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from time import perf_counter
 from typing import Dict, List, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
@@ -42,6 +43,7 @@ class OllamaProvider(LLMProvider):
         port: int = 11434,
         timeout_seconds: Optional[int] = None,
     ) -> None:
+        super().__init__()
         self.model = model
         self.host = host
         self.port = port
@@ -49,6 +51,7 @@ class OllamaProvider(LLMProvider):
         self.base_url = _normalize_base_url(host=host, port=port)
 
     def _complete_json(self, system_prompt: str, user_prompt: str) -> Dict[str, object]:
+        self._log_request("Ollama", self.model, system_prompt, user_prompt)
         payload = json.dumps(
             {
                 "model": self.model,
@@ -66,6 +69,7 @@ class OllamaProvider(LLMProvider):
             headers={"Content-Type": "application/json"},
             method="POST",
         )
+        started_at = perf_counter()
         try:
             if self.timeout_seconds is None:
                 response_context = urlopen(request)
@@ -96,6 +100,7 @@ class OllamaProvider(LLMProvider):
         content = str(message.get("content", "")).strip()
         if not content:
             raise ValueError("Ollama returned an empty response.")
+        self._log_response("Ollama", self.model, content, perf_counter() - started_at)
         return json.loads(content)
 
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:

--- a/src/digester/providers/ollama_provider.py
+++ b/src/digester/providers/ollama_provider.py
@@ -93,7 +93,12 @@ class OllamaProvider(LLMProvider):
                 )
             )
 
-        response_payload = json.loads(body)
+        response_payload = self._parse_json_response(
+            "Ollama",
+            self.model,
+            body,
+            payload_label="HTTP response body",
+        )
         message = response_payload.get("message", {})
         if not isinstance(message, dict):
             raise ValueError("Ollama response did not contain a valid message payload.")
@@ -101,7 +106,7 @@ class OllamaProvider(LLMProvider):
         if not content:
             raise ValueError("Ollama returned an empty response.")
         self._log_response("Ollama", self.model, content, perf_counter() - started_at)
-        return json.loads(content)
+        return self._parse_json_response("Ollama", self.model, content)
 
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
         payload = self._complete_json(

--- a/src/digester/providers/openai_provider.py
+++ b/src/digester/providers/openai_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from time import perf_counter
 from typing import Dict, List, Optional
 
 from ..core.models import DigestBatchRequest, DigestDecision, TopicDigest
@@ -22,6 +23,7 @@ class OpenAIProvider(LLMProvider):
         base_url: Optional[str] = None,
         organization: Optional[str] = None,
     ) -> None:
+        super().__init__()
         if not api_key:
             raise ValueError("An API key is required for hosted or compatible OpenAI clients.")
         self.model = model
@@ -112,6 +114,8 @@ class OpenAIProvider(LLMProvider):
 
     def _complete_json(self, system_prompt: str, user_prompt: str) -> Dict[str, object]:
         client = self._client()
+        self._log_request("OpenAI", self.model, system_prompt, user_prompt)
+        started_at = perf_counter()
         try:
             response = client.chat.completions.create(
                 model=self.model,
@@ -126,6 +130,7 @@ class OpenAIProvider(LLMProvider):
         content = response.choices[0].message.content
         if not content:
             raise ValueError("Model returned an empty response.")
+        self._log_response("OpenAI", self.model, content, perf_counter() - started_at)
         return json.loads(content)
 
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:

--- a/src/digester/providers/openai_provider.py
+++ b/src/digester/providers/openai_provider.py
@@ -131,7 +131,7 @@ class OpenAIProvider(LLMProvider):
         if not content:
             raise ValueError("Model returned an empty response.")
         self._log_response("OpenAI", self.model, content, perf_counter() - started_at)
-        return json.loads(content)
+        return self._parse_json_response("OpenAI", self.model, content)
 
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
         payload = self._complete_json(

--- a/src/digester/utils/progress.py
+++ b/src/digester/utils/progress.py
@@ -19,6 +19,9 @@ class ProgressReporter:
     def verbose(self, message: str) -> None:
         raise NotImplementedError
 
+    def verbosity(self) -> int:
+        raise NotImplementedError
+
     def clear(self) -> None:
         raise NotImplementedError
 
@@ -33,14 +36,23 @@ class NoOpProgressReporter(ProgressReporter):
     def verbose(self, message: str) -> None:
         return None
 
+    def verbosity(self) -> int:
+        return 0
+
     def clear(self) -> None:
         return None
 
 
 class ConsoleProgressReporter(ProgressReporter):
-    def __init__(self, stream: Optional[TextIO] = None, verbose: bool = False) -> None:
+    def __init__(
+        self,
+        stream: Optional[TextIO] = None,
+        verbose_level: int = 0,
+        rewrite_updates: bool = True,
+    ) -> None:
         self.stream = stream or sys.stderr
-        self.verbose_enabled = verbose
+        self.verbose_level = verbose_level
+        self.rewrite_updates = rewrite_updates
         self._last_line_length = 0
 
     def _clear_line(self) -> None:
@@ -51,6 +63,9 @@ class ConsoleProgressReporter(ProgressReporter):
 
     def update(self, message: str) -> None:
         rendered = message.strip()
+        if not self.rewrite_updates:
+            self.persist(rendered)
+            return None
         self.stream.write("\r" + rendered)
         if self._last_line_length > len(rendered):
             self.stream.write(" " * (self._last_line_length - len(rendered)))
@@ -63,9 +78,12 @@ class ConsoleProgressReporter(ProgressReporter):
         self.stream.flush()
 
     def verbose(self, message: str) -> None:
-        if not self.verbose_enabled:
+        if self.verbose_level <= 0:
             return None
         self.persist(message)
+
+    def verbosity(self) -> int:
+        return self.verbose_level
 
     def clear(self) -> None:
         self._clear_line()

--- a/src/digester/utils/progress.py
+++ b/src/digester/utils/progress.py
@@ -16,6 +16,9 @@ class ProgressReporter:
     def persist(self, message: str) -> None:
         raise NotImplementedError
 
+    def verbose(self, message: str) -> None:
+        raise NotImplementedError
+
     def clear(self) -> None:
         raise NotImplementedError
 
@@ -27,13 +30,17 @@ class NoOpProgressReporter(ProgressReporter):
     def persist(self, message: str) -> None:
         return None
 
+    def verbose(self, message: str) -> None:
+        return None
+
     def clear(self) -> None:
         return None
 
 
 class ConsoleProgressReporter(ProgressReporter):
-    def __init__(self, stream: Optional[TextIO] = None) -> None:
+    def __init__(self, stream: Optional[TextIO] = None, verbose: bool = False) -> None:
         self.stream = stream or sys.stderr
+        self.verbose_enabled = verbose
         self._last_line_length = 0
 
     def _clear_line(self) -> None:
@@ -54,6 +61,11 @@ class ConsoleProgressReporter(ProgressReporter):
         self._clear_line()
         self.stream.write(message.strip() + "\n")
         self.stream.flush()
+
+    def verbose(self, message: str) -> None:
+        if not self.verbose_enabled:
+            return None
+        self.persist(message)
 
     def clear(self) -> None:
         self._clear_line()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,7 +313,7 @@ def test_cli_passes_verbose_reporter_to_provider(monkeypatch, tmp_path: Path, ca
     capsys.readouterr()
     assert exit_code == 0
     assert isinstance(provider.progress_reporter, ConsoleProgressReporter)
-    assert provider.progress_reporter.verbose_enabled is True
+    assert provider.progress_reporter.verbosity() == 1
 
 
 def test_cli_short_verbose_flag_is_supported() -> None:
@@ -332,6 +332,84 @@ def test_cli_short_verbose_flag_is_supported() -> None:
     )
 
     assert args.verbose is True
+    assert args.vv is False
+
+
+def test_cli_double_verbose_flag_is_supported() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "digest",
+            "notes.txt",
+            "--output-dir",
+            "artifacts",
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+            "--vv",
+        ]
+    )
+
+    assert args.vv is True
+    assert args.verbose is False
+
+
+def test_cli_passes_double_verbose_reporter_to_provider(monkeypatch, tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    provider = CliFakeProvider()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(cli, "create_provider", lambda settings: provider)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+            "--vv",
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert isinstance(provider.progress_reporter, ConsoleProgressReporter)
+    assert provider.progress_reporter.verbosity() == 2
+
+
+def test_cli_writes_logs_to_file(monkeypatch, tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    log_path = tmp_path / "logs" / "bookworm.log"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+            "--log-location",
+            str(log_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    log_text = log_path.read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert "Using provider mock-llm with model fake-model." not in captured.err
+    assert "Using provider mock-llm with model fake-model." in log_text
+    assert "Finished digestion with 1 skill file(s)." in log_text
 
 
 def test_cli_mock_llm_runs_without_api_key(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from digester.core.models import DigestBatchRequest, DigestDecision, TopicDigest
 from digester.interfaces import cli
 from digester.providers import ProviderSettings
 from digester.providers.base import LLMProvider
+from digester.utils.progress import ConsoleProgressReporter
 
 
 class CliFakeProvider(LLMProvider):
@@ -285,6 +286,52 @@ def test_cli_ollama_timeout_defaults_to_none(monkeypatch, tmp_path: Path, capsys
     capsys.readouterr()
     assert exit_code == 0
     assert seen["timeout_seconds"] is None
+
+
+def test_cli_passes_verbose_reporter_to_provider(monkeypatch, tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    provider = CliFakeProvider()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(cli, "create_provider", lambda settings: provider)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+            "--verbose",
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert isinstance(provider.progress_reporter, ConsoleProgressReporter)
+    assert provider.progress_reporter.verbose_enabled is True
+
+
+def test_cli_short_verbose_flag_is_supported() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "digest",
+            "notes.txt",
+            "--output-dir",
+            "artifacts",
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+            "-v",
+        ]
+    )
+
+    assert args.verbose is True
 
 
 def test_cli_mock_llm_runs_without_api_key(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -335,6 +335,104 @@ def test_openai_provider_verbose_logging_reports_request_and_response(monkeypatc
     assert any("response preview" in message for message in verbose_messages)
 
 
+def test_openai_provider_reports_invalid_json_with_context(monkeypatch) -> None:
+    provider = OpenAIProvider(model="gpt-5-nano", api_key="test-key")
+    invalid_content = '{"topic_updates": [], "should_continue": false "rationale": "broken"}'
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kwargs: SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content=invalid_content))]
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    with pytest.raises(ValueError) as exc_info:
+        provider.digest_batch(
+            DigestBatchRequest(
+                config=DigestConfig(),
+                batch_number=1,
+                total_batches=1,
+                chunk_batch=[],
+                current_topics=[],
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "OpenAI model gpt-5-nano returned invalid JSON in the model response" in message
+    assert "Expecting ',' delimiter" in message
+    assert "Received 69 chars." in message
+    assert '<<<HERE>>>"<<<HERE>>>rationale' in message
+
+
+def test_ollama_provider_reports_invalid_model_json_with_context(monkeypatch) -> None:
+    provider = OllamaProvider(model="llama3.1")
+    invalid_content = '{"topic_updates": [], "should_continue": false "rationale": "broken"}'
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"message": {"content": invalid_content}}).encode("utf-8")
+
+    monkeypatch.setattr("digester.providers.ollama_provider.urlopen", lambda request: FakeResponse())
+
+    with pytest.raises(ValueError) as exc_info:
+        provider.digest_batch(
+            DigestBatchRequest(
+                config=DigestConfig(),
+                batch_number=1,
+                total_batches=1,
+                chunk_batch=[],
+                current_topics=[],
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "Ollama model llama3.1 returned invalid JSON in the model response" in message
+    assert "Expecting ',' delimiter" in message
+    assert "Received 69 chars." in message
+    assert '<<<HERE>>>"<<<HERE>>>rationale' in message
+
+
+def test_ollama_provider_reports_invalid_http_body_with_context(monkeypatch) -> None:
+    provider = OllamaProvider(model="llama3.1")
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return b'{"message": {"content": "oops"}'
+
+    monkeypatch.setattr("digester.providers.ollama_provider.urlopen", lambda request: FakeResponse())
+
+    with pytest.raises(ValueError) as exc_info:
+        provider.digest_batch(
+            DigestBatchRequest(
+                config=DigestConfig(),
+                batch_number=1,
+                total_batches=1,
+                chunk_batch=[],
+                current_topics=[],
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "Ollama model llama3.1 returned invalid JSON in the HTTP response body" in message
+    assert "Expecting ',' delimiter" in message
+    assert '<<<HERE>>><EOF><<<HERE>>>' in message
+
+
 def test_openai_provider_validate_configuration_reports_model_access(monkeypatch) -> None:
     provider = OpenAIProvider(model="gpt-5-nano", api_key="test-key")
     request = httpx.Request("GET", "https://api.openai.com/v1/models/gpt-5-nano")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -18,6 +18,23 @@ from digester.providers.ollama_provider import OllamaProvider, _normalize_base_u
 from digester.providers.openai_provider import OpenAIProvider
 
 
+class RecordingVerboseReporter:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def update(self, message: str) -> None:
+        self.messages.append(("update", message))
+
+    def persist(self, message: str) -> None:
+        self.messages.append(("persist", message))
+
+    def verbose(self, message: str) -> None:
+        self.messages.append(("verbose", message))
+
+    def clear(self) -> None:
+        self.messages.append(("clear", ""))
+
+
 def test_create_provider_builds_mock_llm_provider() -> None:
     provider = create_provider(
         ProviderSettings(
@@ -236,6 +253,86 @@ def test_ollama_provider_uses_explicit_timeout_when_configured(monkeypatch) -> N
     )
 
     assert seen["timeout"] == 90
+
+
+def test_ollama_provider_verbose_logging_reports_request_and_response(monkeypatch) -> None:
+    provider = OllamaProvider(model="llama3.1")
+    reporter = RecordingVerboseReporter()
+    provider.set_progress_reporter(reporter)
+    timing_points = iter([10.0, 12.5])
+
+    long_system_prompt = "S" * 300
+    long_user_prompt = "U" * 280
+    response_content = json.dumps(
+        {
+            "topic_updates": [],
+            "should_continue": False,
+            "rationale": "Done.",
+        }
+    )
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"message": {"content": response_content}}).encode("utf-8")
+
+    monkeypatch.setattr("digester.providers.ollama_provider.urlopen", lambda request: FakeResponse())
+    monkeypatch.setattr("digester.providers.ollama_provider.perf_counter", lambda: next(timing_points))
+
+    payload = provider._complete_json(
+        system_prompt=long_system_prompt,
+        user_prompt=long_user_prompt,
+    )
+
+    verbose_messages = [message for kind, message in reporter.messages if kind == "verbose"]
+    assert payload["rationale"] == "Done."
+    assert any("sending 580 chars to Ollama model llama3.1" in message for message in verbose_messages)
+    assert any("request preview" in message and "[omitted 60 chars]" in message for message in verbose_messages)
+    assert any("returned {count} chars in 2.50s".format(count=len(response_content)) in message for message in verbose_messages)
+    assert any("response preview" in message for message in verbose_messages)
+
+
+def test_openai_provider_verbose_logging_reports_request_and_response(monkeypatch) -> None:
+    provider = OpenAIProvider(model="gpt-5-nano", api_key="test-key")
+    reporter = RecordingVerboseReporter()
+    provider.set_progress_reporter(reporter)
+    timing_points = iter([100.0, 101.75])
+
+    response_content = json.dumps(
+        {
+            "topic_updates": [],
+            "should_continue": False,
+            "rationale": "Enough context collected.",
+        }
+    )
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kwargs: SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content=response_content))]
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+    monkeypatch.setattr("digester.providers.openai_provider.perf_counter", lambda: next(timing_points))
+
+    payload = provider._complete_json(
+        system_prompt="system prompt",
+        user_prompt="user prompt " + ("x" * 260),
+    )
+
+    verbose_messages = [message for kind, message in reporter.messages if kind == "verbose"]
+    assert payload["rationale"] == "Enough context collected."
+    assert any("sending 285 chars to OpenAI model gpt-5-nano" in message for message in verbose_messages)
+    assert any("request preview" in message and "[omitted 32 chars]" in message for message in verbose_messages)
+    assert any("returned {count} chars in 1.75s".format(count=len(response_content)) in message for message in verbose_messages)
+    assert any("response preview" in message for message in verbose_messages)
 
 
 def test_openai_provider_validate_configuration_reports_model_access(monkeypatch) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -21,6 +21,7 @@ from digester.providers.openai_provider import OpenAIProvider
 class RecordingVerboseReporter:
     def __init__(self) -> None:
         self.messages = []
+        self.verbose_level = 1
 
     def update(self, message: str) -> None:
         self.messages.append(("update", message))
@@ -30,6 +31,9 @@ class RecordingVerboseReporter:
 
     def verbose(self, message: str) -> None:
         self.messages.append(("verbose", message))
+
+    def verbosity(self) -> int:
+        return self.verbose_level
 
     def clear(self) -> None:
         self.messages.append(("clear", ""))
@@ -333,6 +337,40 @@ def test_openai_provider_verbose_logging_reports_request_and_response(monkeypatc
     assert any("request preview" in message and "[omitted 32 chars]" in message for message in verbose_messages)
     assert any("returned {count} chars in 1.75s".format(count=len(response_content)) in message for message in verbose_messages)
     assert any("response preview" in message for message in verbose_messages)
+
+
+def test_openai_provider_double_verbose_logging_keeps_full_body(monkeypatch) -> None:
+    provider = OpenAIProvider(model="gpt-5-nano", api_key="test-key")
+    reporter = RecordingVerboseReporter()
+    reporter.verbose_level = 2
+    provider.set_progress_reporter(reporter)
+    timing_points = iter([1.0, 1.25])
+    user_prompt = "user prompt " + ("x" * 260)
+    response_content = json.dumps(
+        {
+            "topic_updates": [],
+            "should_continue": False,
+            "rationale": "Enough context collected.",
+        }
+    )
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kwargs: SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content=response_content))]
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+    monkeypatch.setattr("digester.providers.openai_provider.perf_counter", lambda: next(timing_points))
+
+    provider._complete_json(system_prompt="system prompt", user_prompt=user_prompt)
+
+    verbose_messages = [message for kind, message in reporter.messages if kind == "verbose"]
+    assert any("request body" in message for message in verbose_messages)
+    assert any(user_prompt in message for message in verbose_messages)
+    assert not any("[omitted" in message for message in verbose_messages if "request body" in message)
 
 
 def test_openai_provider_reports_invalid_json_with_context(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add a `--verbose` / `-v` CLI flag for detailed LLM diagnostics during digest runs
- log truncated request and response previews with character counts and round-trip timing for OpenAI and Ollama calls
- cover CLI wiring and provider verbose logging behavior in tests, and document the new flag in the README