### PR TITLE
Persist in-progress skills during digestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bookworm Digester
 
-Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, and writes completed section-like skill files into agent-native skill directories for downstream Copilot, OpenCode, and Codex workflows.
+Bookworm Digester ingests source documents, incrementally digests them through an LLM-guided loop, and writes section-like skill files into agent-native skill directories for downstream Copilot, OpenCode, and Codex workflows as topics evolve and then finalize.
 
 Each output file is meant to behave like a reusable skill file for another agent: focused enough to stand alone, but still traceable back to the source material.
 
@@ -89,4 +89,4 @@ bookworm digest docs/*.txt \
 
 ## Loop semantics
 
-The digester always keeps processing remaining chunks unless it hits `--max-batches`. The provider's `should_continue` flag is narrower: it tells the orchestrator whether the **currently visible** section-like topics likely continue into adjacent chunks, not whether the whole corpus is finished. When the provider marks the visible cluster complete, Bookworm finalizes and writes those topic files immediately, then continues scanning later chunks for new topics. That keeps long runs from holding every completed topic in memory until the very end.
+The digester always keeps processing remaining chunks unless it hits `--max-batches`. The provider's `should_continue` flag is narrower: it tells the orchestrator whether the **currently visible** section-like topics likely continue into adjacent chunks, not whether the whole corpus is finished. After each batch, Bookworm rewrites the current in-progress skill files so partial progress is preserved on disk. When the provider marks the visible cluster complete, Bookworm finalizes and rewrites those topic files immediately, then continues scanning later chunks for new topics. If finalization fails, Bookworm leaves the latest in-progress files on disk before surfacing the error.

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -254,9 +254,10 @@ The orchestrator lives in `src/digester/core/orchestrator.py`.
 3. For each batch:
    - pass the currently active topics and new chunks to the provider
    - merge returned topic updates into the in-memory topic map
+   - rewrite the current in-progress skill files so partial output survives interruptions
    - treat `should_continue` as guidance about whether the visible topics likely continue into nearby chunks
 4. When the provider marks the visible topic cluster complete, finalize that cluster for export and clear it from the active in-memory map
-5. Write completed topic files incrementally
+5. Rewrite finalized topic files incrementally as clusters close
 6. Finalize any remaining active topics after the last batch
 7. Return a `DigestResult`
 
@@ -268,6 +269,7 @@ The loop ends when any of the following happens:
 - `max_batches` is reached
 
 Provider completion does not stop corpus traversal on its own. It only marks the current topic cluster as sufficiently covered.
+If a provider error occurs after in-memory topics already exist, the orchestrator writes the latest in-progress topic files before re-raising the error.
 
 ### 7.3 Why the Loop Is "Adaptive"
 

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -31,6 +31,7 @@ class DigestOrchestrator:
         self,
         documents: List[SourceDocument],
         on_topics_finalized: Optional[Callable[[Sequence[TopicDigest]], None]] = None,
+        on_topics_updated: Optional[Callable[[Sequence[TopicDigest]], None]] = None,
     ) -> DigestResult:
         self.progress_reporter.update(
             "Chunking {count} loaded document(s).".format(count=len(documents))
@@ -77,66 +78,78 @@ class DigestOrchestrator:
             topic_map.clear()
             active_topic_slugs.clear()
 
-        for batch_index in range(total_batches):
-            start = batch_index * self.config.batch_size
-            chunk_batch = chunks[start : start + self.config.batch_size]
-            if not chunk_batch:
-                break
-            current_topics = ensure_topics_limited(
-                [topic_map[slug] for slug in active_topic_slugs if slug in topic_map],
-                self.config.max_active_topics,
-            )
-            batch_files = sorted({file_label(chunk.source_path) for chunk in chunk_batch})
-            self.progress_reporter.update(
-                "Digesting batch {current}/{total} for {files}.".format(
-                    current=batch_index + 1,
-                    total=total_batches,
-                    files=", ".join(batch_files),
+        try:
+            for batch_index in range(total_batches):
+                start = batch_index * self.config.batch_size
+                chunk_batch = chunks[start : start + self.config.batch_size]
+                if not chunk_batch:
+                    break
+                current_topics = ensure_topics_limited(
+                    [topic_map[slug] for slug in active_topic_slugs if slug in topic_map],
+                    self.config.max_active_topics,
                 )
-            )
-            request = DigestBatchRequest(
-                config=self.config,
-                batch_number=batch_index + 1,
-                total_batches=total_batches,
-                chunk_batch=chunk_batch,
-                current_topics=current_topics,
-            )
-            decision = self.provider.digest_batch(request)
-            for update in decision.topic_updates:
-                existing = topic_map.get(update.slug)
-                if existing is None:
-                    topic_map[update.slug] = update
+                batch_files = sorted({file_label(chunk.source_path) for chunk in chunk_batch})
+                self.progress_reporter.update(
+                    "Digesting batch {current}/{total} for {files}.".format(
+                        current=batch_index + 1,
+                        total=total_batches,
+                        files=", ".join(batch_files),
+                    )
+                )
+                request = DigestBatchRequest(
+                    config=self.config,
+                    batch_number=batch_index + 1,
+                    total_batches=total_batches,
+                    chunk_batch=chunk_batch,
+                    current_topics=current_topics,
+                )
+                decision = self.provider.digest_batch(request)
+                for update in decision.topic_updates:
+                    existing = topic_map.get(update.slug)
+                    if existing is None:
+                        topic_map[update.slug] = update
+                        if update.slug in active_topic_slugs:
+                            active_topic_slugs.remove(update.slug)
+                        active_topic_slugs.append(update.slug)
+                        continue
+                    existing.merge(update)
+                    existing.summary = collapse_topic_summary(existing.summary)
                     if update.slug in active_topic_slugs:
                         active_topic_slugs.remove(update.slug)
                     active_topic_slugs.append(update.slug)
-                    continue
-                existing.merge(update)
-                existing.summary = collapse_topic_summary(existing.summary)
-                if update.slug in active_topic_slugs:
-                    active_topic_slugs.remove(update.slug)
-                active_topic_slugs.append(update.slug)
-            self.progress_reporter.persist(
-                "Completed batch {current}/{total}; tracking {topics} topic(s).".format(
-                    current=batch_index + 1,
-                    total=total_batches,
-                    topics=len(topic_map),
-                )
-            )
-            if (
-                not decision.should_continue
-                and batch_index + 1 >= self.config.minimum_batches_before_stop
-            ):
-                flush_topic_cluster(
-                    "Batch {current}/{total} marked the current topic cluster as complete: {reason}".format(
+                self.progress_reporter.persist(
+                    "Completed batch {current}/{total}; tracking {topics} topic(s).".format(
                         current=batch_index + 1,
                         total=total_batches,
-                        reason=decision.rationale
-                        or "Provider reported the visible section-like topics looked complete.",
-                    ),
+                        topics=len(topic_map),
+                    )
                 )
+                if topic_map and on_topics_updated is not None:
+                    on_topics_updated(list(topic_map.values()))
+                if (
+                    not decision.should_continue
+                    and batch_index + 1 >= self.config.minimum_batches_before_stop
+                ):
+                    flush_topic_cluster(
+                        "Batch {current}/{total} marked the current topic cluster as complete: {reason}".format(
+                            current=batch_index + 1,
+                            total=total_batches,
+                            reason=decision.rationale
+                            or "Provider reported the visible section-like topics looked complete.",
+                        ),
+                    )
 
-        self.progress_reporter.update("Finalizing topic digests.")
-        flush_topic_cluster()
+            self.progress_reporter.update("Finalizing topic digests.")
+            flush_topic_cluster()
+        except Exception:
+            if topic_map and on_topics_updated is not None:
+                self.progress_reporter.persist(
+                    "Persisting {count} in-progress topic digest(s) after an error.".format(
+                        count=len(topic_map)
+                    )
+                )
+                on_topics_updated(list(topic_map.values()))
+            raise
         topics = [finalized_topics[slug] for slug in finalized_topic_order]
         if not topics:
             raise ValueError("The provider returned no topics for the supplied corpus.")

--- a/src/digester/interfaces/api.py
+++ b/src/digester/interfaces/api.py
@@ -48,11 +48,27 @@ class DocumentDigester:
                 )
             )
 
+        def write_in_progress_topics(topics):
+            self.progress_reporter.persist(
+                "Persisting {count} in-progress topic digest(s).".format(count=len(topics))
+            )
+            artifact_paths.update(
+                self.artifact_writer.write_topics(
+                    topics,
+                    output_path,
+                    progress_reporter=self.progress_reporter,
+                )
+            )
+
         result = DigestOrchestrator(
             provider=self.provider,
             config=self.config,
             progress_reporter=self.progress_reporter,
-        ).run(documents, on_topics_finalized=write_completed_topics)
+        ).run(
+            documents,
+            on_topics_finalized=write_completed_topics,
+            on_topics_updated=write_in_progress_topics,
+        )
         result.artifact_paths = artifact_paths
         self.progress_reporter.persist(
             "Finished digestion with {count} skill file(s).".format(count=len(result.topics))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import List
 
+import pytest
+
 from digester.core import DigestConfig
 from digester.core.models import DigestBatchRequest, DigestDecision, TopicDigest
 from digester.interfaces.api import DocumentDigester
@@ -244,8 +246,81 @@ def test_document_digester_flushes_completed_topics_incrementally(tmp_path: Path
     ).digest_paths([input_path], output_dir)
 
     assert provider.finalize_calls == [["topic-1"], ["topic-2"], ["topic-3"]]
-    assert writer.topic_batches == [["topic-1"], ["topic-2"], ["topic-3"]]
+    assert writer.topic_batches == [
+        ["topic-1"],
+        ["topic-1"],
+        ["topic-2"],
+        ["topic-2"],
+        ["topic-3"],
+        ["topic-3"],
+    ]
     assert [topic.slug for topic in result.topics] == ["topic-1", "topic-2", "topic-3"]
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-1" / "SKILL.md").exists()
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-2" / "SKILL.md").exists()
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-3" / "SKILL.md").exists()
+
+
+def test_document_digester_persists_in_progress_topics_after_each_batch(tmp_path: Path) -> None:
+    input_path = tmp_path / "topics.txt"
+    input_path.write_text(
+        "Topic one.\n\nTopic two.\n\nTopic three.",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+    writer = RecordingArtifactWriter()
+
+    result = DocumentDigester(
+        provider=LimitedBatchProvider(),
+        config=DigestConfig(max_chunk_chars=20, batch_size=1, max_batches=2),
+        artifact_writer=writer,
+    ).digest_paths([input_path], output_dir)
+
+    assert writer.topic_batches == [
+        ["topics-chunk-1"],
+        ["topics-chunk-1", "topics-chunk-2"],
+        ["topics-chunk-1", "topics-chunk-2"],
+    ]
+    assert [topic.slug for topic in result.topics] == ["topics-chunk-1", "topics-chunk-2"]
+    assert (output_dir / "copilot" / ".github" / "skills" / "topics-chunk-1" / "SKILL.md").exists()
+    assert (output_dir / "copilot" / ".github" / "skills" / "topics-chunk-2" / "SKILL.md").exists()
+
+
+class EmptyFinalizeProvider(LLMProvider):
+    def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
+        chunk = request.chunk_batch[0]
+        return DigestDecision(
+            topic_updates=[
+                TopicDigest(
+                    slug="recovered-topic",
+                    title="Recovered Topic",
+                    summary="Summary retained before finalization failed.",
+                    key_points=["Keep the partial artifact on disk."],
+                    references=[chunk.source_ref],
+                )
+            ],
+            should_continue=False,
+            rationale="This topic is complete.",
+        )
+
+    def finalize_topics(self, topics: List[TopicDigest]) -> List[TopicDigest]:
+        return []
+
+
+def test_document_digester_keeps_in_progress_files_when_finalize_fails(tmp_path: Path) -> None:
+    input_path = tmp_path / "topics.txt"
+    input_path.write_text("Topic one.", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    reporter = RecordingReporter()
+
+    with pytest.raises(ValueError, match="The provider returned no topics for the supplied corpus."):
+        DocumentDigester(
+            provider=EmptyFinalizeProvider(),
+            config=DigestConfig(max_chunk_chars=20, batch_size=1, minimum_batches_before_stop=1),
+            progress_reporter=reporter,
+        ).digest_paths([input_path], output_dir)
+
+    skill_path = output_dir / "copilot" / ".github" / "skills" / "recovered-topic" / "SKILL.md"
+    assert skill_path.exists()
+    persisted = [message for kind, message in reporter.messages if kind == "persist"]
+    assert any("Persisting 1 in-progress topic digest(s)." == message for message in persisted)
+    assert any("Persisting 1 in-progress topic digest(s) after an error." == message for message in persisted)


### PR DESCRIPTION
## Summary
- rewrite the current in-progress SKILL.md files after each batch so partial output lands on disk immediately
- persist the in-memory topic cluster before re-raising provider and finalization errors
- add tests covering per-batch persistence and the exact no-topics finalization failure path

## Testing
- PYTHONPATH=src .venv/bin/pytest -q