### PR TITLE
Fix topic continuity for reopened slugs

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -287,6 +287,7 @@ This allows the provider to accumulate understanding and decide whether visible 
 Topic updates from the provider are merged by `slug`. This makes provider output idempotent enough to support iterative digestion:
 
 - the same logical topic can be enriched across batches
+- reopened slugs from later finalized clusters are merged back into the existing finalized topic
 - duplicate bullets and references are removed
 - summaries are collapsed to reduce line-level repetition
 

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -69,16 +69,19 @@ class DigestOrchestrator:
             )
             if reason:
                 self.progress_reporter.persist(reason)
+            merged_topics: List[TopicDigest] = []
             for topic in topics:
                 existing_finalized = finalized_topics.get(topic.slug)
                 if existing_finalized is None:
                     finalized_topic_order.append(topic.slug)
                     finalized_topics[topic.slug] = topic
+                    merged_topics.append(topic)
                     continue
                 existing_finalized.merge(topic)
                 existing_finalized.summary = collapse_topic_summary(existing_finalized.summary)
+                merged_topics.append(existing_finalized)
             if on_topics_finalized is not None:
-                on_topics_finalized(topics)
+                on_topics_finalized(merged_topics)
             topic_map.clear()
             active_topic_slugs.clear()
 

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -70,9 +70,13 @@ class DigestOrchestrator:
             if reason:
                 self.progress_reporter.persist(reason)
             for topic in topics:
-                if topic.slug not in finalized_topics:
+                existing_finalized = finalized_topics.get(topic.slug)
+                if existing_finalized is None:
                     finalized_topic_order.append(topic.slug)
-                finalized_topics[topic.slug] = topic
+                    finalized_topics[topic.slug] = topic
+                    continue
+                existing_finalized.merge(topic)
+                existing_finalized.summary = collapse_topic_summary(existing_finalized.summary)
             if on_topics_finalized is not None:
                 on_topics_finalized(topics)
             topic_map.clear()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -223,9 +223,11 @@ class RecordingArtifactWriter(MarkdownArtifactWriter):
     def __init__(self) -> None:
         super().__init__()
         self.topic_batches: List[List[str]] = []
+        self.topic_summaries: List[dict[str, str]] = []
 
     def write_topics(self, topics, output_dir, progress_reporter=None):
         self.topic_batches.append([topic.slug for topic in topics])
+        self.topic_summaries.append({topic.slug: topic.summary for topic in topics})
         return super().write_topics(topics, output_dir, progress_reporter)
 
 
@@ -374,9 +376,11 @@ def test_document_digester_merges_reopened_topics_across_finalized_clusters(tmp_
     third_path.write_text("Architecture follow-up.", encoding="utf-8")
 
     provider = ReopenedTopicProvider()
+    writer = RecordingArtifactWriter()
     result = DocumentDigester(
         provider=provider,
         config=DigestConfig(max_chunk_chars=30, batch_size=1, minimum_batches_before_stop=1),
+        artifact_writer=writer,
     ).digest_paths([first_path, second_path, third_path], tmp_path / "out")
 
     assert provider.finalize_calls == [["architecture"], ["testing"], ["architecture"]]
@@ -386,3 +390,14 @@ def test_document_digester_merges_reopened_topics_across_finalized_clusters(tmp_
     assert "Architecture notes from batch 3." in architecture.summary
     assert architecture.key_points == ["Architecture point 1", "Architecture point 3"]
     assert len(architecture.references) == 2
+    assert writer.topic_batches == [
+        ["architecture"],
+        ["architecture"],
+        ["testing"],
+        ["testing"],
+        ["architecture"],
+        ["architecture"],
+    ]
+    assert writer.topic_summaries[-1]["architecture"] == architecture.summary
+    assert "Architecture notes from batch 1." in writer.topic_summaries[-1]["architecture"]
+    assert "Architecture notes from batch 3." in writer.topic_summaries[-1]["architecture"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -324,3 +324,65 @@ def test_document_digester_keeps_in_progress_files_when_finalize_fails(tmp_path:
     persisted = [message for kind, message in reporter.messages if kind == "persist"]
     assert any("Persisting 1 in-progress topic digest(s)." == message for message in persisted)
     assert any("Persisting 1 in-progress topic digest(s) after an error." == message for message in persisted)
+
+
+class ReopenedTopicProvider(LLMProvider):
+    def __init__(self) -> None:
+        self.finalize_calls: List[List[str]] = []
+
+    def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
+        chunk = request.chunk_batch[0]
+        if request.batch_number == 2:
+            return DigestDecision(
+                topic_updates=[
+                    TopicDigest(
+                        slug="testing",
+                        title="Testing",
+                        summary="Captures validation flow.",
+                        key_points=["Run the checks after each change."],
+                        references=[chunk.source_ref],
+                    )
+                ],
+                should_continue=False,
+                rationale="The testing topic is complete for this chunk.",
+            )
+        return DigestDecision(
+            topic_updates=[
+                TopicDigest(
+                    slug="architecture",
+                    title="Architecture",
+                    summary="Architecture notes from batch {batch}.".format(batch=request.batch_number),
+                    key_points=["Architecture point {batch}".format(batch=request.batch_number)],
+                    references=[chunk.source_ref],
+                )
+            ],
+            should_continue=False,
+            rationale="The visible topic cluster is complete.",
+        )
+
+    def finalize_topics(self, topics: List[TopicDigest]) -> List[TopicDigest]:
+        self.finalize_calls.append([topic.slug for topic in topics])
+        return topics
+
+
+def test_document_digester_merges_reopened_topics_across_finalized_clusters(tmp_path: Path) -> None:
+    first_path = tmp_path / "architecture-a.txt"
+    second_path = tmp_path / "testing.txt"
+    third_path = tmp_path / "architecture-b.txt"
+    first_path.write_text("Architecture introduction.", encoding="utf-8")
+    second_path.write_text("Testing workflow.", encoding="utf-8")
+    third_path.write_text("Architecture follow-up.", encoding="utf-8")
+
+    provider = ReopenedTopicProvider()
+    result = DocumentDigester(
+        provider=provider,
+        config=DigestConfig(max_chunk_chars=30, batch_size=1, minimum_batches_before_stop=1),
+    ).digest_paths([first_path, second_path, third_path], tmp_path / "out")
+
+    assert provider.finalize_calls == [["architecture"], ["testing"], ["architecture"]]
+    assert [topic.slug for topic in result.topics] == ["architecture", "testing"]
+    architecture = result.topics[0]
+    assert "Architecture notes from batch 1." in architecture.summary
+    assert "Architecture notes from batch 3." in architecture.summary
+    assert architecture.key_points == ["Architecture point 1", "Architecture point 3"]
+    assert len(architecture.references) == 2


### PR DESCRIPTION
## Summary
- merge reopened slugs back into the existing finalized topic instead of overwriting it
- add a regression test covering a slug that reappears after another finalized cluster
- document the finalized-topic merge behavior in the technical notes

## Testing
- pytest -q

Closes #11