### PR TITLE
Structure the Bookworm skill contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Bookworm Digester ingests source documents, incrementally digests them through a
 
 Each output file is meant to behave like a reusable skill file for another agent: focused enough to stand alone, but still traceable back to the source material.
 
+Generated `SKILL.md` files preserve dedicated skill-routing data instead of inferring it from the first summary line. Each skill includes:
+
+- YAML frontmatter with an explicit routing `description`
+- `## When To Use` generated from dedicated routing guidance
+- `## Purpose` for the durable summary
+- `## Core Instructions` and `## Workflow Notes` for action-oriented detail
+- source files and source references
+
 By default, each run writes three directories beneath the chosen output directory:
 
 ```text

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -97,8 +97,8 @@ For each successful digestion run, the system must write three agent-targeted ou
 Each generated `SKILL.md` file must contain:
 
 - a stable topic title
-- YAML frontmatter with the skill name and routing description
-- when-to-use guidance that tells a downstream agent when to load the skill
+- YAML frontmatter with the skill name and explicit routing description
+- when-to-use guidance generated from dedicated routing data instead of summary inference
 - a concise purpose summary
 - a list of durable, actionable core instructions
 - workflow notes for using the skill safely with live repository context
@@ -152,6 +152,7 @@ The system may delay acting on provider completion hints until a configurable mi
 ### FR-6 Finalize Topics for Export
 
 Before writing markdown, the system must finalize or refine topic digests through the provider abstraction.
+The finalization contract must preserve an explicit routing field plus structured workflow notes so exported skill files do not have to derive router text from summaries.
 
 ### FR-7 Preserve Source Traceability
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -309,6 +309,8 @@ The user prompt includes:
 - the current chunk batch
 - hard constraints such as max active topics and anti-duplication guidance
 
+The prompt contract treats `routing_description` and `workflow_notes` as first-class topic fields so downstream skill exports do not have to infer router text from summary prose.
+
 ### 8.2 Finalization Prompt
 
 The finalization step asks the model to:
@@ -327,8 +329,10 @@ Digest response shape:
     {
       "slug": "architecture",
       "title": "Architecture",
+      "routing_description": "Use this skill when tracing the current architecture decisions and setup flow.",
       "summary": "Short summary",
       "key_points": ["Fact 1", "Fact 2"],
+      "workflow_notes": ["Check the cited source before applying the summarized workflow."],
       "references": [
         {
           "source_id": "source",
@@ -351,8 +355,10 @@ Finalize response shape:
     {
       "slug": "architecture",
       "title": "Architecture",
+      "routing_description": "Use this skill when tracing the current architecture decisions and setup flow.",
       "summary": "Final concise summary",
       "key_points": ["Fact 1", "Fact 2"],
+      "workflow_notes": ["Check the cited source before applying the summarized workflow."],
       "references": [
         {
           "source_id": "source",
@@ -445,7 +451,7 @@ Each agent export root also includes an `INSTALL.md` file with the documented pr
 - `opencode/INSTALL.md`
 - `codex/INSTALL.md`
 
-The description/frontmatter acts as the routing layer for downstream agents, so the runtime no longer emits a separate top-level `INDEX.md`.
+The description/frontmatter acts as the routing layer for downstream agents and is rendered directly from `TopicDigest.routing_description`, so the runtime no longer has to infer it from the summary body.
 
 ## 11. Public Interfaces
 

--- a/src/digester/core/artifacts.py
+++ b/src/digester/core/artifacts.py
@@ -53,13 +53,6 @@ def _unique_source_paths(topic: TopicDigest):
     return ordered
 
 
-def _topic_routing_description(topic: TopicDigest) -> str:
-    summary = topic.summary.strip()
-    first_line = next((line.strip() for line in summary.splitlines() if line.strip()), topic.title)
-    normalized = first_line.rstrip(".")
-    return "Use this skill when work requires {summary}.".format(summary=normalized)
-
-
 def _render_skill_body(topic: TopicDigest) -> str:
     summary = topic.summary.strip()
     lines = [
@@ -67,7 +60,7 @@ def _render_skill_body(topic: TopicDigest) -> str:
         "",
         "## When To Use",
         "",
-        _topic_routing_description(topic),
+        topic.routing_description.strip(),
         "",
         "## Purpose",
         "",
@@ -77,16 +70,8 @@ def _render_skill_body(topic: TopicDigest) -> str:
         "",
     ]
     lines.extend("- {point}".format(point=point) for point in topic.key_points)
-    lines.extend(
-        [
-            "",
-            "## Workflow Notes",
-            "",
-            "- Load this skill when the task matches the frontmatter description and the guidance below.",
-            "- Treat the instructions above as source-backed context, not as a replacement for checking current repository code.",
-            "- Use the source references when a decision depends on exact wording, provenance, or missing detail.",
-        ]
-    )
+    lines.extend(["", "## Workflow Notes", ""])
+    lines.extend("- {note}".format(note=note) for note in topic.workflow_notes)
     source_paths = _unique_source_paths(topic)
     if source_paths:
         lines.extend(["", "## Source files", ""])
@@ -111,7 +96,7 @@ def _render_skill_markdown(
     frontmatter_lines = [
         "---",
         "name: {name}".format(name=skill_dir_name),
-        "description: {description}".format(description=json.dumps(_topic_routing_description(topic))),
+        "description: {description}".format(description=json.dumps(topic.routing_description.strip())),
     ]
     if layout.compatibility:
         frontmatter_lines.append("compatibility: {compatibility}".format(compatibility=layout.compatibility))

--- a/src/digester/core/artifacts.py
+++ b/src/digester/core/artifacts.py
@@ -70,8 +70,9 @@ def _render_skill_body(topic: TopicDigest) -> str:
         "",
     ]
     lines.extend("- {point}".format(point=point) for point in topic.key_points)
-    lines.extend(["", "## Workflow Notes", ""])
-    lines.extend("- {note}".format(note=note) for note in topic.workflow_notes)
+    if topic.workflow_notes:
+        lines.extend(["", "## Workflow Notes", ""])
+        lines.extend("- {note}".format(note=note) for note in topic.workflow_notes)
     source_paths = _unique_source_paths(topic)
     if source_paths:
         lines.extend(["", "## Source files", ""])

--- a/src/digester/core/models.py
+++ b/src/digester/core/models.py
@@ -17,6 +17,32 @@ def _dedupe_preserve_order(items: Iterable[str]) -> List[str]:
     return result
 
 
+def _dedupe_source_refs(refs: Iterable["SourceRef"]) -> List["SourceRef"]:
+    seen = set()
+    ordered_refs: List[SourceRef] = []
+    for ref in refs:
+        key = (ref.source_id, ref.source_path, ref.locator)
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered_refs.append(ref)
+    return ordered_refs
+
+
+def _merge_prefer_richer_text(current: str, update: str) -> str:
+    current = current.strip()
+    update = update.strip()
+    if not update:
+        return current
+    if not current:
+        return update
+    if current == update:
+        return current
+    if len(update) > len(current):
+        return update
+    return current
+
+
 @dataclass(frozen=True)
 class SourceRef:
     source_id: str
@@ -63,10 +89,16 @@ class TopicDigest:
     slug: str
     title: str
     summary: str
+    routing_description: str = ""
     key_points: List[str] = field(default_factory=list)
+    workflow_notes: List[str] = field(default_factory=list)
     references: List[SourceRef] = field(default_factory=list)
 
     def merge(self, other: "TopicDigest") -> None:
+        self.routing_description = _merge_prefer_richer_text(
+            self.routing_description,
+            other.routing_description,
+        )
         if other.summary:
             if self.summary:
                 self.summary = "{current}\n\n{update}".format(
@@ -76,16 +108,8 @@ class TopicDigest:
             else:
                 self.summary = other.summary.strip()
         self.key_points = _dedupe_preserve_order(self.key_points + other.key_points)
-        combined_refs = self.references + other.references
-        seen = set()
-        ordered_refs: List[SourceRef] = []
-        for ref in combined_refs:
-            key = (ref.source_id, ref.source_path, ref.locator)
-            if key in seen:
-                continue
-            seen.add(key)
-            ordered_refs.append(ref)
-        self.references = ordered_refs
+        self.workflow_notes = _dedupe_preserve_order(self.workflow_notes + other.workflow_notes)
+        self.references = _dedupe_source_refs(self.references + other.references)
 
 
 @dataclass
@@ -149,12 +173,19 @@ class DigestDecision:
                 if not parsed_refs:
                     parsed_refs = list(fallback_refs)
                 key_points = raw_topic.get("key_points", [])
+                workflow_notes = raw_topic.get("workflow_notes", [])
                 topic_updates.append(
                     TopicDigest(
                         slug=str(raw_topic.get("slug", "")).strip(),
                         title=str(raw_topic.get("title", "")).strip(),
+                        routing_description=str(
+                            raw_topic.get("routing_description", raw_topic.get("when_to_use", ""))
+                        ).strip(),
                         summary=str(raw_topic.get("summary", "")).strip(),
                         key_points=[str(point).strip() for point in key_points or [] if str(point).strip()],
+                        workflow_notes=[
+                            str(note).strip() for note in workflow_notes or [] if str(note).strip()
+                        ],
                         references=parsed_refs,
                     )
                 )
@@ -188,15 +219,7 @@ def combine_references(topics: Sequence[TopicDigest]) -> List[SourceRef]:
     refs: List[SourceRef] = []
     for topic in topics:
         refs.extend(topic.references)
-    unique_refs: List[SourceRef] = []
-    seen = set()
-    for ref in refs:
-        key = (ref.source_id, ref.source_path, ref.locator)
-        if key in seen:
-            continue
-        seen.add(key)
-        unique_refs.append(ref)
-    return unique_refs
+    return _dedupe_source_refs(refs)
 
 
 def topic_lookup(topics: Sequence[TopicDigest]) -> Dict[str, TopicDigest]:

--- a/src/digester/core/models.py
+++ b/src/digester/core/models.py
@@ -179,7 +179,7 @@ class DigestDecision:
                         slug=str(raw_topic.get("slug", "")).strip(),
                         title=str(raw_topic.get("title", "")).strip(),
                         routing_description=str(
-                            raw_topic.get("routing_description", raw_topic.get("when_to_use", ""))
+                            raw_topic.get("routing_description") or raw_topic.get("when_to_use") or ""
                         ).strip(),
                         summary=str(raw_topic.get("summary", "")).strip(),
                         key_points=[str(point).strip() for point in key_points or [] if str(point).strip()],

--- a/src/digester/core/prompts.py
+++ b/src/digester/core/prompts.py
@@ -14,11 +14,13 @@ def build_digest_system_prompt() -> str:
         "configuration values, validation checks, warnings, failure conditions, and recovery notes. "
         "Compress repetition, but do not compress away procedures, dependencies, sequencing, or concrete implementation detail. "
         "Return strict JSON with keys: topic_updates, should_continue, rationale. "
-        "Each topic update must include slug, title, summary, key_points, references. "
+        "Each topic update must include slug, title, routing_description, summary, key_points, workflow_notes, references. "
         "references must contain source_id, source_path, locator. "
         "Treat each topic like a section-level skill file that another agent could discover from a SKILL.md description and reuse on its own. "
-        "Write summaries as routing-friendly purpose statements: what task the skill helps with, what context it preserves, and when an agent should load it. "
-        "Write key_points as actionable instructions, constraints, workflow steps, commands, checks, or caveats, not vague observations. "
+        "routing_description must explicitly say when another agent should load the skill. "
+        "Write summaries as markdown-ready purpose statements that explain what task the skill helps with and what context it preserves. "
+        "Write key_points as actionable instructions, constraints, workflow steps, commands, or checks, not vague observations. "
+        "workflow_notes must preserve caveats, validation checks, warnings, and source-backed operator guidance. "
         "Set should_continue to false only when the current visible topics already have strong coverage and the next chunks are more likely to introduce different topics than extend these ones."
     )
 
@@ -28,8 +30,10 @@ def build_digest_user_prompt(request: DigestBatchRequest) -> str:
         {
             "slug": topic.slug,
             "title": topic.title,
+            "routing_description": topic.routing_description,
             "summary": topic.summary,
             "key_points": topic.key_points,
+            "workflow_notes": topic.workflow_notes,
             "references": [ref.render() for ref in topic.references],
         }
         for topic in request.current_topics
@@ -51,10 +55,11 @@ def build_digest_user_prompt(request: DigestBatchRequest) -> str:
         "Constraints:\n"
         "- Keep at most {max_topics} active topics in view for this batch.\n"
         "- Topics should behave like section-level skill files for coding agents: each one should cover a coherent, reusable slice of the source rather than the whole corpus.\n"
-        "- Summaries should be rich, actionable, routing-friendly, and markdown-ready, usually 2-5 compact paragraphs when the material supports it.\n"
-        "- The first summary sentence should make clear when an agent should load the skill.\n"
+        "- routing_description must say when another agent should load the skill, without copying the title.\n"
+        "- Summaries should be rich, actionable, and markdown-ready, usually 2-5 compact paragraphs when the material supports it.\n"
         "- Preserve setup sequences, hardware steps, prerequisites, commands, parameter values, safety notes, verification steps, and troubleshooting clues when present.\n"
         "- Key points should be concrete, imperative when useful, and numerous enough to preserve important detail; prefer roughly 5-12 bullets when the source is dense.\n"
+        "- workflow_notes should preserve validation checks, caveats, escalation hints, and source-backed usage notes.\n"
         "- Prefer operational rules, workflow steps, constraints, examples, commands, validation checks, and failure modes over generic observations.\n"
         "- Merge overlapping ideas instead of creating duplicates.\n"
         "- Favor detail that helps another engineer or agent reproduce the setup, understand the implementation, or avoid mistakes.\n"
@@ -72,10 +77,11 @@ def build_finalize_system_prompt() -> str:
     return (
         "You are preparing final topic digests for markdown export as agent-readable skill files. "
         "Return strict JSON with a single key named topics. "
-        "Each topic must include slug, title, summary, key_points, references. "
+        "Each topic must include slug, title, routing_description, summary, key_points, workflow_notes, references. "
         "Produce rich markdown-ready summaries that keep the most useful implementation and setup detail. Each topic should read like a reusable skill file for coding agents such as Codex, Claude Code, and Copilot. "
-        "The first sentence of each summary must say when to use the skill. "
-        "Key points must be actionable instructions, constraints, ordered workflow guidance, examples, commands, checks, warnings, or caveats. "
+        "routing_description must be explicit enough to drive frontmatter description and a When To Use section without inferring it from the summary. "
+        "Key points must be actionable instructions, constraints, ordered workflow guidance, examples, commands, or checks. "
+        "workflow_notes must preserve validation checks, warnings, caveats, and source-backed operating guidance. "
         "Do not collapse away hardware setup flows, ordered procedures, commands, prerequisites, warnings, validation checks, or troubleshooting notes. "
         "Remove duplication, but preserve concrete facts and enough detail that another LLM or engineer could act on the output without rereading the whole source."
     )
@@ -86,15 +92,18 @@ def build_finalize_user_prompt(topics: Sequence[TopicDigest]) -> str:
         {
             "slug": topic.slug,
             "title": topic.title,
+            "routing_description": topic.routing_description,
             "summary": topic.summary,
             "key_points": topic.key_points,
+            "workflow_notes": topic.workflow_notes,
             "references": [ref.render() for ref in topic.references],
         }
         for topic in topics
     ]
     return (
         "Finalize these topics for markdown export. Expand weak summaries into more useful detail where the existing topic data supports it. "
-        "Shape each topic as a routed skill: make the first summary sentence explain when to load it, and rewrite key points into operational guidance an agent can follow. "
+        "Make routing_description strong enough for a frontmatter description and When To Use section. "
+        "Make workflow_notes capture validation checks, caveats, and source-backed operating guidance. "
         "Keep the output concise enough for downstream context windows, but detailed enough to preserve setup flow, operational nuance, and important edge cases.\n"
         "{payload}"
     ).format(payload=json.dumps(payload, indent=2))

--- a/src/digester/providers/mock_llm_provider.py
+++ b/src/digester/providers/mock_llm_provider.py
@@ -80,6 +80,9 @@ class MockLLMProvider(LLMProvider):
                 TopicDigest(
                     slug=self._topic_slug_for(source_id=source_id, source_path=source_path),
                     title="Mock {label}".format(label=_titleize(label)),
+                    routing_description=(
+                        "Use this skill when validating the digested workflow for {label} without a live LLM."
+                    ).format(label=label),
                     summary=(
                         "end-to-end validation for {label} without a real LLM response.\n\n"
                         "MockLLM generated this placeholder from source metadata and preserved "
@@ -89,6 +92,10 @@ class MockLLMProvider(LLMProvider):
                         "Treat this topic as synthetic fixture output for ingestion, orchestration, and artifact export checks.",
                         "MockLLM keeps real source references so downstream skills still point at the original files.",
                         "Switch to a real provider before using generated summaries for implementation or product decisions.",
+                    ],
+                    workflow_notes=[
+                        "Confirm the real provider contract before treating the placeholder routing text as production-ready.",
+                        "Use the preserved source references when comparing mock output to a real skill export.",
                     ],
                     references=grouped_refs[(source_id, source_path)],
                 )

--- a/src/digester/providers/parsing.py
+++ b/src/digester/providers/parsing.py
@@ -34,8 +34,14 @@ def parse_finalized_topics(payload: Dict[str, object], fallback_topics: List[Top
             TopicDigest(
                 slug=str(raw_topic.get("slug", "")).strip(),
                 title=str(raw_topic.get("title", "")).strip(),
+                routing_description=str(
+                    raw_topic.get("routing_description", raw_topic.get("when_to_use", ""))
+                ).strip(),
                 summary=str(raw_topic.get("summary", "")).strip(),
                 key_points=[str(point).strip() for point in raw_topic.get("key_points", []) if str(point).strip()],
+                workflow_notes=[
+                    str(note).strip() for note in raw_topic.get("workflow_notes", []) if str(note).strip()
+                ],
                 references=refs,
             )
         )

--- a/src/digester/providers/parsing.py
+++ b/src/digester/providers/parsing.py
@@ -35,7 +35,7 @@ def parse_finalized_topics(payload: Dict[str, object], fallback_topics: List[Top
                 slug=str(raw_topic.get("slug", "")).strip(),
                 title=str(raw_topic.get("title", "")).strip(),
                 routing_description=str(
-                    raw_topic.get("routing_description", raw_topic.get("when_to_use", ""))
+                    raw_topic.get("routing_description") or raw_topic.get("when_to_use") or ""
                 ).strip(),
                 summary=str(raw_topic.get("summary", "")).strip(),
                 key_points=[str(point).strip() for point in raw_topic.get("key_points", []) if str(point).strip()],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,8 +20,10 @@ class CliFakeProvider(LLMProvider):
                 TopicDigest(
                     slug="summary",
                     title="Summary",
+                    routing_description="Use this skill when reviewing the concise document summary.",
                     summary="Captures the essential content.",
                     key_points=["Produces markdown output"],
+                    workflow_notes=["Open the generated skill before sharing it with another agent."],
                     references=[chunk.source_ref for chunk in request.chunk_batch],
                 )
             ],

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -220,8 +220,10 @@ class FinalizeEachBatchProvider(LLMProvider):
                 TopicDigest(
                     slug="topic-{batch}".format(batch=request.batch_number),
                     title="Topic {batch}".format(batch=request.batch_number),
+                    routing_description="",
                     summary="Summary {batch}".format(batch=request.batch_number),
                     key_points=["Point {batch}".format(batch=request.batch_number)],
+                    workflow_notes=[],
                     references=[chunk.source_ref],
                 )
             ],
@@ -270,9 +272,11 @@ def test_document_digester_flushes_completed_topics_incrementally(tmp_path: Path
         ["topic-3"],
     ]
     assert [topic.slug for topic in result.topics] == ["topic-1", "topic-2", "topic-3"]
+    skill_text = (output_dir / "copilot" / ".github" / "skills" / "topic-1" / "SKILL.md").read_text(encoding="utf-8")
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-1" / "SKILL.md").exists()
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-2" / "SKILL.md").exists()
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-3" / "SKILL.md").exists()
+    assert "## Workflow Notes" not in skill_text
 
 
 def test_document_digester_persists_in_progress_topics_after_each_batch(tmp_path: Path) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,6 +19,7 @@ class FakeProvider(LLMProvider):
         topic = TopicDigest(
             slug="architecture",
             title="Architecture",
+            routing_description="Use this skill when tracing the system architecture and setup flow.",
             summary=(
                 "Summarizes the system design and interfaces.\n\n"
                 "Includes enough operational detail to help another engineer follow the setup flow."
@@ -27,6 +28,10 @@ class FakeProvider(LLMProvider):
                 "Uses adapters for ingestion",
                 "Emits section-like skill files",
                 "Preserves setup detail for downstream readers",
+            ],
+            workflow_notes=[
+                "Verify the current repository flow before treating the digest as authoritative.",
+                "Use the cited source paths when exact setup wording matters.",
             ],
             references=[chunk.source_ref for chunk in request.chunk_batch],
         )
@@ -92,12 +97,14 @@ def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
     assert not (output_dir / "copilot" / "installer.sh").exists()
     assert not (output_dir / "INDEX.md").exists()
     assert 'name: architecture' in topic_text
-    assert 'description: "Use this skill when work requires Summarizes the system design and interfaces."' in topic_text
+    assert 'description: "Use this skill when tracing the system architecture and setup flow."' in topic_text
     assert "## When To Use" in topic_text
     assert "## Purpose" in topic_text
     assert "## Core Instructions" in topic_text
     assert "## Workflow Notes" in topic_text
     assert "## Source files" in topic_text
+    assert "Verify the current repository flow before treating the digest as authoritative." in topic_text
+    assert "Use this skill when work requires Summarizes the system design and interfaces." not in topic_text
     assert "compatibility: opencode" in opencode_text
     assert "Project: `.github/skills/<skill-name>/SKILL.md`" in copilot_install_text
     assert "Global: `~/.copilot/skills/<skill-name>/SKILL.md`" in copilot_install_text
@@ -127,8 +134,12 @@ class ManyTopicProvider(LLMProvider):
                 TopicDigest(
                     slug="skill-{batch}".format(batch=batch_number),
                     title="Skill {batch}".format(batch=batch_number),
+                    routing_description="Use this skill when working with skill batch {batch}.".format(
+                        batch=batch_number
+                    ),
                     summary="Summary for chunk {batch}.".format(batch=batch_number),
                     key_points=["Point {batch}".format(batch=batch_number)],
+                    workflow_notes=["Validate skill batch {batch} before reuse.".format(batch=batch_number)],
                     references=[chunk.source_ref],
                 )
             ],
@@ -169,8 +180,12 @@ class LimitedBatchProvider(LLMProvider):
                 TopicDigest(
                     slug=chunk.chunk_id,
                     title=chunk.chunk_id,
+                    routing_description="Use this skill when following the {chunk} workflow.".format(
+                        chunk=chunk.chunk_id
+                    ),
                     summary="Summary",
                     key_points=["Point"],
+                    workflow_notes=["Check the cited source before automating the step."],
                     references=[chunk.source_ref],
                 )
             ],
@@ -293,8 +308,10 @@ class EmptyFinalizeProvider(LLMProvider):
                 TopicDigest(
                     slug="recovered-topic",
                     title="Recovered Topic",
+                    routing_description="Use this skill when recovering the partially finalized topic output.",
                     summary="Summary retained before finalization failed.",
                     key_points=["Keep the partial artifact on disk."],
+                    workflow_notes=["Inspect the in-progress file before rerunning finalization."],
                     references=[chunk.source_ref],
                 )
             ],

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -36,12 +36,13 @@ def test_digest_prompts_preserve_setup_and_hardware_detail() -> None:
     assert "section-level skill file" in system_prompt
     assert "Codex, Claude Code, and Copilot" in system_prompt
     assert "SKILL.md description" in system_prompt
-    assert "routing-friendly purpose statements" in system_prompt
+    assert "routing_description" in system_prompt
+    assert "workflow_notes" in system_prompt
     assert "setup sequences" in user_prompt
     assert "verification steps" in user_prompt
     assert "5-12 bullets" in user_prompt
     assert "active topics in view" in user_prompt
-    assert "first summary sentence" in user_prompt
+    assert "routing_description must say when another agent should load the skill" in user_prompt
     assert "operational rules" in user_prompt
     assert "later chunks may contain different topics" in user_prompt
 
@@ -53,8 +54,10 @@ def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
             TopicDigest(
                 slug="hardware-setup",
                 title="Hardware setup",
+                routing_description="Use this skill when bringing the hardware setup online.",
                 summary="Short summary",
                 key_points=["Attach the board"],
+                workflow_notes=["Validate the LED state before moving on."],
                 references=[
                     SourceRef(
                         source_id="setup-guide",
@@ -67,10 +70,8 @@ def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
     )
 
     assert "hardware setup flows" in system_prompt
-    assert "commands, prerequisites, warnings, validation checks" in system_prompt
-    assert "reusable skill file" in system_prompt
-    assert "first sentence of each summary must say when to use the skill" in system_prompt
-    assert "actionable instructions" in system_prompt
+    assert "routing_description" in system_prompt
+    assert "workflow_notes" in system_prompt
     assert "Expand weak summaries" in user_prompt
-    assert "routed skill" in user_prompt
+    assert "Make routing_description strong enough" in user_prompt
     assert "setup flow, operational nuance, and important edge cases" in user_prompt

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,6 +15,7 @@ from digester.core.models import (
 )
 from digester.providers import MockLLMProvider, ProviderSettings, create_provider
 from digester.providers.ollama_provider import OllamaProvider, _normalize_base_url
+from digester.providers.parsing import parse_finalized_topics
 from digester.providers.openai_provider import OpenAIProvider
 
 
@@ -130,10 +131,12 @@ def test_mock_llm_provider_generates_deterministic_placeholder_topics() -> None:
     )
     assert [topic.slug for topic in decision.topic_updates] == ["mock-alpha-notes", "mock-beta-notes"]
     assert [topic.title for topic in decision.topic_updates] == ["Mock Alpha Notes", "Mock Beta Notes"]
+    assert all(topic.routing_description.startswith("Use this skill when validating") for topic in decision.topic_updates)
     assert all(
         "without semantically parsing the document content" in topic.summary
         for topic in decision.topic_updates
     )
+    assert all(topic.workflow_notes for topic in decision.topic_updates)
     assert all(topic.references for topic in decision.topic_updates)
 
 
@@ -157,8 +160,10 @@ def test_ollama_provider_digest_batch(monkeypatch) -> None:
                                     {
                                         "slug": "overview",
                                         "title": "Overview",
+                                        "routing_description": "Use this skill when reviewing the locally digested overview.",
                                         "summary": "Condenses the current source.",
                                         "key_points": ["Uses Ollama locally"],
+                                        "workflow_notes": ["Validate the local model output before reuse."],
                                         "references": [
                                             {
                                                 "source_id": "source",
@@ -190,6 +195,11 @@ def test_ollama_provider_digest_batch(monkeypatch) -> None:
 
     assert decision.should_continue is False
     assert decision.topic_updates[0].slug == "overview"
+    assert (
+        decision.topic_updates[0].routing_description
+        == "Use this skill when reviewing the locally digested overview."
+    )
+    assert decision.topic_updates[0].workflow_notes == ["Validate the local model output before reuse."]
 
 
 def test_ollama_provider_reports_connection_failure(monkeypatch) -> None:
@@ -206,8 +216,10 @@ def test_ollama_provider_reports_connection_failure(monkeypatch) -> None:
                 TopicDigest(
                     slug="overview",
                     title="Overview",
+                    routing_description="Use this skill when reviewing the finalized overview guidance.",
                     summary="Summary",
                     key_points=["Point"],
+                    workflow_notes=["Re-run the provider once Ollama connectivity is restored."],
                     references=[SourceRef(source_id="source", source_path="/tmp/source.txt", locator="full-document")],
                 )
             ]
@@ -257,6 +269,47 @@ def test_ollama_provider_uses_explicit_timeout_when_configured(monkeypatch) -> N
     )
 
     assert seen["timeout"] == 90
+
+
+def test_parse_finalized_topics_preserves_structured_skill_fields() -> None:
+    fallback_topic = TopicDigest(
+        slug="fallback",
+        title="Fallback",
+        routing_description="Use this skill when fallback output is required.",
+        summary="Fallback summary.",
+        key_points=["Fallback point"],
+        workflow_notes=["Fallback note"],
+        references=[SourceRef(source_id="fallback", source_path="/tmp/fallback.txt", locator="full-document")],
+    )
+
+    parsed = parse_finalized_topics(
+        {
+            "topics": [
+                {
+                    "slug": "overview",
+                    "title": "Overview",
+                    "routing_description": "Use this skill when reviewing the finalized overview guidance.",
+                    "summary": "Condenses the finalized source.",
+                    "key_points": ["Check the finalized guidance before editing."],
+                    "workflow_notes": ["Validate the cited source before applying the summarized workflow."],
+                    "references": [
+                        {
+                            "source_id": "source",
+                            "source_path": "/tmp/source.txt",
+                            "locator": "full-document",
+                        }
+                    ],
+                }
+            ]
+        },
+        fallback_topics=[fallback_topic],
+    )
+
+    assert len(parsed) == 1
+    assert parsed[0].routing_description == "Use this skill when reviewing the finalized overview guidance."
+    assert parsed[0].workflow_notes == [
+        "Validate the cited source before applying the summarized workflow."
+    ]
 
 
 def test_ollama_provider_verbose_logging_reports_request_and_response(monkeypatch) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -312,6 +312,28 @@ def test_parse_finalized_topics_preserves_structured_skill_fields() -> None:
     ]
 
 
+def test_parse_finalized_topics_treats_null_routing_description_as_empty_string() -> None:
+    parsed = parse_finalized_topics(
+        {
+            "topics": [
+                {
+                    "slug": "overview",
+                    "title": "Overview",
+                    "routing_description": None,
+                    "summary": "Condenses the finalized source.",
+                    "key_points": ["Check the finalized guidance before editing."],
+                    "workflow_notes": [],
+                    "references": [],
+                }
+            ]
+        },
+        fallback_topics=[],
+    )
+
+    assert len(parsed) == 1
+    assert parsed[0].routing_description == ""
+
+
 def test_ollama_provider_verbose_logging_reports_request_and_response(monkeypatch) -> None:
     provider = OllamaProvider(model="llama3.1")
     reporter = RecordingVerboseReporter()


### PR DESCRIPTION
## Summary
- promote `TopicDigest` and provider parsing to preserve explicit routing descriptions and workflow notes
- render `SKILL.md` routing/frontmatter directly from structured skill data instead of inferring it from summaries
- add regression coverage and docs for the richer skill contract

## Testing
- pytest -q

Closes #12