### PR TITLE
cli: add post-digest status report

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ bookworm digest docs/*.txt \
 
 `mock-llm` does not require an API key and intentionally produces synthetic placeholder topics from source metadata so you can validate ingestion, orchestration, and artifact export flows quickly.
 
+After a successful run, the CLI prints a short status report to stdout with the chunk count, configured and realized batch sizes, total chunk chars, batch count, elapsed digestion time, and generated skill count.
+
 ## Loop semantics
 
 The digester always keeps processing remaining chunks unless it hits `--max-batches`. The provider's `should_continue` flag is narrower: it tells the orchestrator whether the **currently visible** section-like topics likely continue into adjacent chunks, not whether the whole corpus is finished. After each batch, Bookworm rewrites the current in-progress skill files so partial progress is preserved on disk. When the provider marks the visible cluster complete, Bookworm finalizes and rewrites those topic files immediately, then continues scanning later chunks for new topics. If finalization fails, Bookworm leaves the latest in-progress files on disk before surfacing the error.

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Optional, Sequence, TextIO, Tuple
 
@@ -161,6 +162,39 @@ def _resolve_api_key(args: argparse.Namespace) -> str:
     return api_key
 
 
+def _batch_sizes(chunk_count: int, batch_size: int) -> Sequence[int]:
+    return [
+        len(range(start, min(start + batch_size, chunk_count)))
+        for start in range(0, chunk_count, batch_size)
+    ]
+
+
+def _status_report(
+    *,
+    chunk_count: int,
+    batch_size: int,
+    total_chars: int,
+    batch_count: int,
+    batch_sizes: Sequence[int],
+    elapsed_seconds: float,
+    skills_generated: int,
+) -> str:
+    return "\n".join(
+        [
+            "Digest status report:",
+            "- Chunks: {count}".format(count=chunk_count),
+            "- Configured batch size: {count}".format(count=batch_size),
+            "- Batch sizes: {sizes}".format(
+                sizes=", ".join(str(size) for size in batch_sizes) or "0"
+            ),
+            "- Total chars: {count}".format(count=total_chars),
+            "- Batches: {count}".format(count=batch_count),
+            "- Elapsed: {elapsed:.2f}s".format(elapsed=elapsed_seconds),
+            "- Skills generated: {count}".format(count=skills_generated),
+        ]
+    )
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -200,13 +234,29 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             ),
             progress_reporter=reporter,
         )
+        started_at = time.perf_counter()
         result = digester.digest_paths(args.inputs, args.output_dir)
+        elapsed_seconds = time.perf_counter() - started_at
+        chunk_count = len(result.chunks)
+        batch_sizes = list(_batch_sizes(chunk_count, args.batch_size))
+        total_chars = sum(len(chunk.text) for chunk in result.chunks)
         agent_targets = len([key for key in result.artifact_paths if ":" not in key])
         print(
             "Wrote {count} skill(s) for {agents} agent target(s) to {output_dir}".format(
                 count=len(result.topics),
                 agents=agent_targets,
                 output_dir=args.output_dir,
+            )
+        )
+        print(
+            _status_report(
+                chunk_count=chunk_count,
+                batch_size=args.batch_size,
+                total_chars=total_chars,
+                batch_count=len(batch_sizes),
+                batch_sizes=batch_sizes,
+                elapsed_seconds=elapsed_seconds,
+                skills_generated=len(result.topics),
             )
         )
         return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,14 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Wrote 1 skill(s) for 3 agent target(s)" in captured.out
+    assert "Digest status report:" in captured.out
+    assert "- Chunks: 1" in captured.out
+    assert "- Configured batch size: 2" in captured.out
+    assert "- Batch sizes: 1" in captured.out
+    assert "- Total chars: 19" in captured.out
+    assert "- Batches: 1" in captured.out
+    assert "- Elapsed: " in captured.out
+    assert "- Skills generated: 1" in captured.out
     assert (output_dir / "copilot" / ".github" / "skills" / "summary" / "SKILL.md").exists()
     assert (output_dir / "opencode" / ".opencode" / "skills" / "summary" / "SKILL.md").exists()
     assert (output_dir / "codex" / ".agents" / "skills" / "summary" / "SKILL.md").exists()
@@ -499,3 +507,39 @@ def test_cli_max_topics_flag_is_kept_as_compatibility_alias() -> None:
     )
 
     assert args.max_active_topics == 7
+
+
+def test_cli_status_report_lists_multiple_batch_sizes(tmp_path: Path, monkeypatch, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text(
+        "One.\n\nTwo.\n\nThree.",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "artifacts"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--provider-kind",
+            "mock-llm",
+            "--model",
+            "fake-model",
+            "--batch-size",
+            "2",
+            "--max-chunk-chars",
+            "8",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "- Chunks: 3" in captured.out
+    assert "- Configured batch size: 2" in captured.out
+    assert "- Batch sizes: 2, 1" in captured.out
+    assert "- Total chars: 14" in captured.out
+    assert "- Batches: 2" in captured.out
+    assert "- Skills generated: 1" in captured.out


### PR DESCRIPTION
Adds a concise status report printed to stdout after digestion reporting chunks, configured and realized batch sizes, total chars, batch count, elapsed time, and skills generated. Includes tests and README update.