### PR TITLE
Add final skill quality gate to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Generated `SKILL.md` files preserve dedicated skill-routing data instead of infe
 - `## Core Instructions` and `## Workflow Notes` for action-oriented detail
 - source files and source references
 
+Before export, Bookworm validates finalized topics so weak routing text, thin workflow guidance, or missing references fail explicitly instead of quietly producing low-signal skills.
+
 By default, each run writes three directories beneath the chosen output directory:
 
 ```text

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -191,6 +191,7 @@ Topic digests must retain enough provenance to let a human or downstream agent k
 ### 9.4 Explicit Failure
 
 Unsupported inputs, missing credentials, empty extraction, and empty model responses must fail explicitly.
+Low-quality finalized skills must also fail explicitly instead of silently falling back to weaker pre-finalized output.
 
 ### 9.5 Controlled Coverage
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -319,6 +319,7 @@ The finalization step asks the model to:
 - refine and compress existing topic digests
 - preserve factual key points
 - return a JSON object with a `topics` list suitable for reusable skill files
+- satisfy export-quality requirements for routing guidance, workflow detail, and references
 
 ### 8.3 Output Schema Expectations
 
@@ -525,6 +526,8 @@ Current error behavior is intentionally explicit:
 
 - unsupported source types raise `ValueError`
 - empty extractable content raises `ValueError`
+- malformed finalized topic payloads raise `ValueError` instead of silently falling back to weaker topic data
+- finalized topics that fail routing/workflow/reference quality checks raise `ValueError` before export
 - empty model response raises `ValueError`
 - missing provider credentials raise `ValueError`
 

--- a/src/digester/core/models.py
+++ b/src/digester/core/models.py
@@ -43,6 +43,10 @@ def _merge_prefer_richer_text(current: str, update: str) -> str:
     return current
 
 
+def _word_count(text: str) -> int:
+    return len([word for word in text.strip().split() if word])
+
+
 @dataclass(frozen=True)
 class SourceRef:
     source_id: str
@@ -224,3 +228,44 @@ def combine_references(topics: Sequence[TopicDigest]) -> List[SourceRef]:
 
 def topic_lookup(topics: Sequence[TopicDigest]) -> Dict[str, TopicDigest]:
     return {topic.slug: topic for topic in topics}
+
+
+def topic_quality_issues(topic: TopicDigest) -> List[str]:
+    issues: List[str] = []
+    routing_description = topic.routing_description.strip()
+    if not routing_description:
+        issues.append("routing_description is required")
+    elif routing_description.rstrip(".").lower() == topic.title.strip().lower():
+        issues.append("routing_description must say when to use the skill, not repeat the title")
+    elif _word_count(routing_description) < 5:
+        issues.append("routing_description must be a specific when-to-use sentence")
+
+    summary = topic.summary.strip()
+    if not summary:
+        issues.append("summary is required")
+    elif _word_count(summary) < 6:
+        issues.append("summary must preserve a useful purpose description")
+
+    actionable_items = [
+        item.strip() for item in topic.key_points + topic.workflow_notes if item.strip()
+    ]
+    if len(actionable_items) < 2:
+        issues.append("at least two actionable instructions or workflow notes are required")
+
+    if not topic.references:
+        issues.append("at least one source reference is required")
+    return issues
+
+
+def validate_topics_for_export(topics: Sequence[TopicDigest]) -> List[TopicDigest]:
+    validated = list(topics)
+    for topic in validated:
+        issues = topic_quality_issues(topic)
+        if issues:
+            raise ValueError(
+                "Finalized topic '{slug}' failed export quality checks: {issues}".format(
+                    slug=topic.slug,
+                    issues="; ".join(issues),
+                )
+            )
+    return validated

--- a/src/digester/core/models.py
+++ b/src/digester/core/models.py
@@ -44,7 +44,7 @@ def _merge_prefer_richer_text(current: str, update: str) -> str:
 
 
 def _word_count(text: str) -> int:
-    return len([word for word in text.strip().split() if word])
+    return len(text.split())
 
 
 @dataclass(frozen=True)

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -62,7 +62,8 @@ class DigestOrchestrator:
         def flush_topic_cluster(reason: Optional[str] = None) -> None:
             if not topic_map:
                 return
-            topics = validate_topics_for_export(self.provider.finalize_topics(list(topic_map.values())))
+            finalized = self.provider.finalize_topics(list(topic_map.values()))
+            topics = validate_topics_for_export(finalized)
             if not topics:
                 raise ValueError("The provider returned no topics for the supplied corpus.")
             self.progress_reporter.persist(

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -13,6 +13,7 @@ from .models import (
     TopicDigest,
     collapse_topic_summary,
     ensure_topics_limited,
+    validate_topics_for_export,
 )
 
 
@@ -61,7 +62,7 @@ class DigestOrchestrator:
         def flush_topic_cluster(reason: Optional[str] = None) -> None:
             if not topic_map:
                 return
-            topics = self.provider.finalize_topics(list(topic_map.values()))
+            topics = validate_topics_for_export(self.provider.finalize_topics(list(topic_map.values())))
             if not topics:
                 raise ValueError("The provider returned no topics for the supplied corpus.")
             self.progress_reporter.persist(

--- a/src/digester/providers/ollama_provider.py
+++ b/src/digester/providers/ollama_provider.py
@@ -141,4 +141,4 @@ class OllamaProvider(LLMProvider):
             system_prompt=build_finalize_system_prompt(),
             user_prompt=build_finalize_user_prompt(topics),
         )
-        return parse_finalized_topics(payload, fallback_topics=topics)
+        return parse_finalized_topics(payload)

--- a/src/digester/providers/openai_provider.py
+++ b/src/digester/providers/openai_provider.py
@@ -148,4 +148,4 @@ class OpenAIProvider(LLMProvider):
             system_prompt=build_finalize_system_prompt(),
             user_prompt=build_finalize_user_prompt(topics),
         )
-        return parse_finalized_topics(payload, fallback_topics=topics)
+        return parse_finalized_topics(payload)

--- a/src/digester/providers/parsing.py
+++ b/src/digester/providers/parsing.py
@@ -13,8 +13,6 @@ def parse_digest_decision(
 
 
 def parse_finalized_topics(payload: Dict[str, object]) -> List[TopicDigest]:
-    if "topics" not in payload:
-        raise ValueError("Finalized topic payload must contain a topics list.")
     finalized = payload.get("topics")
     if not isinstance(finalized, list):
         raise ValueError("Finalized topic payload must contain a topics list.")

--- a/src/digester/providers/parsing.py
+++ b/src/digester/providers/parsing.py
@@ -12,10 +12,12 @@ def parse_digest_decision(
     return DigestDecision.from_payload(payload, fallback_refs=fallback_refs)
 
 
-def parse_finalized_topics(payload: Dict[str, object], fallback_topics: List[TopicDigest]) -> List[TopicDigest]:
-    finalized = payload.get("topics", [])
+def parse_finalized_topics(payload: Dict[str, object]) -> List[TopicDigest]:
+    if "topics" not in payload:
+        raise ValueError("Finalized topic payload must contain a topics list.")
+    finalized = payload.get("topics")
     if not isinstance(finalized, list):
-        return fallback_topics
+        raise ValueError("Finalized topic payload must contain a topics list.")
 
     result: List[TopicDigest] = []
     for raw_topic in finalized:
@@ -46,4 +48,6 @@ def parse_finalized_topics(payload: Dict[str, object], fallback_topics: List[Top
             )
         )
     parsed_topics = [topic for topic in result if topic.slug and topic.title]
-    return parsed_topics or fallback_topics
+    if not parsed_topics:
+        raise ValueError("Finalized topic payload contained no valid topics.")
+    return parsed_topics

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,8 +21,11 @@ class CliFakeProvider(LLMProvider):
                     slug="summary",
                     title="Summary",
                     routing_description="Use this skill when reviewing the concise document summary.",
-                    summary="Captures the essential content.",
-                    key_points=["Produces markdown output"],
+                    summary="Captures the essential content and preserves the main points for downstream review.",
+                    key_points=[
+                        "Produces markdown output",
+                        "Preserves source-backed guidance for later review",
+                    ],
                     workflow_notes=["Open the generated skill before sharing it with another agent."],
                     references=[chunk.source_ref for chunk in request.chunk_batch],
                 )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -364,7 +364,6 @@ def test_document_digester_keeps_in_progress_files_when_finalize_fails(tmp_path:
     assert any("Persisting 1 in-progress topic digest(s) after an error." == message for message in persisted)
 
 
-<<<<<<< HEAD
 class ReopenedTopicProvider(LLMProvider):
     def __init__(self) -> None:
         self.finalize_calls: List[List[str]] = []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -137,8 +137,13 @@ class ManyTopicProvider(LLMProvider):
                     routing_description="Use this skill when working with skill batch {batch}.".format(
                         batch=batch_number
                     ),
-                    summary="Summary for chunk {batch}.".format(batch=batch_number),
-                    key_points=["Point {batch}".format(batch=batch_number)],
+                    summary=(
+                        "Summarizes the operational detail preserved in chunk {batch} for later reuse."
+                    ).format(batch=batch_number),
+                    key_points=[
+                        "Point {batch}".format(batch=batch_number),
+                        "Follow-up point {batch}".format(batch=batch_number),
+                    ],
                     workflow_notes=["Validate skill batch {batch} before reuse.".format(batch=batch_number)],
                     references=[chunk.source_ref],
                 )
@@ -183,8 +188,8 @@ class LimitedBatchProvider(LLMProvider):
                     routing_description="Use this skill when following the {chunk} workflow.".format(
                         chunk=chunk.chunk_id
                     ),
-                    summary="Summary",
-                    key_points=["Point"],
+                    summary="Summarizes the workflow steps captured for this chunk so they can be reused safely.",
+                    key_points=["Point", "Follow the referenced workflow carefully."],
                     workflow_notes=["Check the cited source before automating the step."],
                     references=[chunk.source_ref],
                 )
@@ -220,10 +225,19 @@ class FinalizeEachBatchProvider(LLMProvider):
                 TopicDigest(
                     slug="topic-{batch}".format(batch=request.batch_number),
                     title="Topic {batch}".format(batch=request.batch_number),
-                    routing_description="",
-                    summary="Summary {batch}".format(batch=request.batch_number),
-                    key_points=["Point {batch}".format(batch=request.batch_number)],
-                    workflow_notes=[],
+                    routing_description="Use this skill when reviewing topic batch {batch}.".format(
+                        batch=request.batch_number
+                    ),
+                    summary="Summarizes the finalized guidance captured for topic batch {batch}.".format(
+                        batch=request.batch_number
+                    ),
+                    key_points=[
+                        "Point {batch}".format(batch=request.batch_number),
+                        "Recheck the cited source before relying on topic batch {batch}.".format(
+                            batch=request.batch_number
+                        ),
+                    ],
+                    workflow_notes=["Validate topic batch {batch} before export.".format(batch=request.batch_number)],
                     references=[chunk.source_ref],
                 )
             ],
@@ -278,7 +292,8 @@ def test_document_digester_flushes_completed_topics_incrementally(tmp_path: Path
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-1" / "SKILL.md").exists()
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-2" / "SKILL.md").exists()
     assert (output_dir / "copilot" / ".github" / "skills" / "topic-3" / "SKILL.md").exists()
-    assert "## Workflow Notes" not in skill_text
+    assert "## Workflow Notes" in skill_text
+    assert "Validate topic batch 1 before export." in skill_text
 
 
 def test_document_digester_persists_in_progress_topics_after_each_batch(tmp_path: Path) -> None:
@@ -349,6 +364,7 @@ def test_document_digester_keeps_in_progress_files_when_finalize_fails(tmp_path:
     assert any("Persisting 1 in-progress topic digest(s) after an error." == message for message in persisted)
 
 
+<<<<<<< HEAD
 class ReopenedTopicProvider(LLMProvider):
     def __init__(self) -> None:
         self.finalize_calls: List[List[str]] = []
@@ -361,8 +377,13 @@ class ReopenedTopicProvider(LLMProvider):
                     TopicDigest(
                         slug="testing",
                         title="Testing",
-                        summary="Captures validation flow.",
-                        key_points=["Run the checks after each change."],
+                        routing_description="Use this skill when validating the current implementation changes.",
+                        summary="Captures the validation flow and the checks that should follow each implementation change.",
+                        key_points=[
+                            "Run the checks after each change.",
+                            "Keep the validation loop close to the code path you modified.",
+                        ],
+                        workflow_notes=["Re-open the source material when a check fails unexpectedly."],
                         references=[chunk.source_ref],
                     )
                 ],
@@ -374,8 +395,15 @@ class ReopenedTopicProvider(LLMProvider):
                 TopicDigest(
                     slug="architecture",
                     title="Architecture",
-                    summary="Architecture notes from batch {batch}.".format(batch=request.batch_number),
-                    key_points=["Architecture point {batch}".format(batch=request.batch_number)],
+                    routing_description="Use this skill when tracing architecture decisions across the corpus.",
+                    summary=(
+                        "Architecture notes from batch {batch} that preserve the design details for later reuse."
+                    ).format(batch=request.batch_number),
+                    key_points=[
+                        "Architecture point {batch}".format(batch=request.batch_number),
+                        "Reconcile architecture changes with earlier finalized guidance.",
+                    ],
+                    workflow_notes=["Validate the architecture note against the cited source chunk."],
                     references=[chunk.source_ref],
                 )
             ],
@@ -407,9 +435,13 @@ def test_document_digester_merges_reopened_topics_across_finalized_clusters(tmp_
     assert provider.finalize_calls == [["architecture"], ["testing"], ["architecture"]]
     assert [topic.slug for topic in result.topics] == ["architecture", "testing"]
     architecture = result.topics[0]
-    assert "Architecture notes from batch 1." in architecture.summary
-    assert "Architecture notes from batch 3." in architecture.summary
-    assert architecture.key_points == ["Architecture point 1", "Architecture point 3"]
+    assert "Architecture notes from batch 1 that preserve the design details for later reuse." in architecture.summary
+    assert "Architecture notes from batch 3 that preserve the design details for later reuse." in architecture.summary
+    assert architecture.key_points == [
+        "Architecture point 1",
+        "Reconcile architecture changes with earlier finalized guidance.",
+        "Architecture point 3",
+    ]
     assert len(architecture.references) == 2
     assert writer.topic_batches == [
         ["architecture"],
@@ -420,5 +452,34 @@ def test_document_digester_merges_reopened_topics_across_finalized_clusters(tmp_
         ["architecture"],
     ]
     assert writer.topic_summaries[-1]["architecture"] == architecture.summary
-    assert "Architecture notes from batch 1." in writer.topic_summaries[-1]["architecture"]
-    assert "Architecture notes from batch 3." in writer.topic_summaries[-1]["architecture"]
+    assert "Architecture notes from batch 1 that preserve the design details for later reuse." in writer.topic_summaries[-1]["architecture"]
+    assert "Architecture notes from batch 3 that preserve the design details for later reuse." in writer.topic_summaries[-1]["architecture"]
+
+
+class WeakQualityProvider(LLMProvider):
+    def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
+        chunk = request.chunk_batch[0]
+        return DigestDecision(
+            topic_updates=[
+                TopicDigest(
+                    slug="weak-skill",
+                    title="Weak skill",
+                    summary="Too short.",
+                    key_points=["Thin point"],
+                    references=[chunk.source_ref],
+                )
+            ],
+            should_continue=False,
+            rationale="No more context needed.",
+        )
+
+
+def test_document_digester_rejects_low_quality_finalized_topics(tmp_path: Path) -> None:
+    input_path = tmp_path / "source.txt"
+    input_path.write_text("A weak topic input.", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="failed export quality checks"):
+        DocumentDigester(
+            provider=WeakQualityProvider(),
+            config=DigestConfig(max_chunk_chars=40, batch_size=1, minimum_batches_before_stop=1),
+        ).digest_paths([input_path], tmp_path / "out")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -272,16 +272,6 @@ def test_ollama_provider_uses_explicit_timeout_when_configured(monkeypatch) -> N
 
 
 def test_parse_finalized_topics_preserves_structured_skill_fields() -> None:
-    fallback_topic = TopicDigest(
-        slug="fallback",
-        title="Fallback",
-        routing_description="Use this skill when fallback output is required.",
-        summary="Fallback summary.",
-        key_points=["Fallback point"],
-        workflow_notes=["Fallback note"],
-        references=[SourceRef(source_id="fallback", source_path="/tmp/fallback.txt", locator="full-document")],
-    )
-
     parsed = parse_finalized_topics(
         {
             "topics": [
@@ -301,8 +291,7 @@ def test_parse_finalized_topics_preserves_structured_skill_fields() -> None:
                     ],
                 }
             ]
-        },
-        fallback_topics=[fallback_topic],
+        }
     )
 
     assert len(parsed) == 1
@@ -326,12 +315,21 @@ def test_parse_finalized_topics_treats_null_routing_description_as_empty_string(
                     "references": [],
                 }
             ]
-        },
-        fallback_topics=[],
+        }
     )
 
     assert len(parsed) == 1
     assert parsed[0].routing_description == ""
+
+
+def test_parse_finalized_topics_requires_topics_list() -> None:
+    with pytest.raises(ValueError, match="must contain a topics list"):
+        parse_finalized_topics({})
+
+
+def test_parse_finalized_topics_rejects_empty_valid_topic_list() -> None:
+    with pytest.raises(ValueError, match="contained no valid topics"):
+        parse_finalized_topics({"topics": [{"slug": "", "title": ""}]})
 
 
 def test_ollama_provider_verbose_logging_reports_request_and_response(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- bring the issue #13 quality-gate implementation onto main after the original PR was accidentally based on another feature branch
- validate finalized topics before export and fail explicitly on weak routing, thin guidance, or missing references
- add regression coverage for malformed finalized payloads and low-quality finalized skills

## Testing
- pytest -q tests/test_pipeline.py tests/test_providers.py tests/test_cli.py

Closes #13