### PR TITLE
Preserve structured topic references during finalization

### DIFF
--- a/src/digester/core/prompts.py
+++ b/src/digester/core/prompts.py
@@ -6,6 +6,17 @@ from typing import Sequence
 from .models import DigestBatchRequest, TopicDigest
 
 
+def _source_ref_payload(topic: TopicDigest):
+    return [
+        {
+            "source_id": ref.source_id,
+            "source_path": ref.source_path,
+            "locator": ref.locator,
+        }
+        for ref in topic.references
+    ]
+
+
 def build_digest_system_prompt() -> str:
     return (
         "You are a document digestion engine. Read the supplied chunks, update a section-like skill map of the corpus, "
@@ -34,7 +45,7 @@ def build_digest_user_prompt(request: DigestBatchRequest) -> str:
             "summary": topic.summary,
             "key_points": topic.key_points,
             "workflow_notes": topic.workflow_notes,
-            "references": [ref.render() for ref in topic.references],
+            "references": _source_ref_payload(topic),
         }
         for topic in request.current_topics
     ]
@@ -96,7 +107,7 @@ def build_finalize_user_prompt(topics: Sequence[TopicDigest]) -> str:
             "summary": topic.summary,
             "key_points": topic.key_points,
             "workflow_notes": topic.workflow_notes,
-            "references": [ref.render() for ref in topic.references],
+            "references": _source_ref_payload(topic),
         }
         for topic in topics
     ]

--- a/src/digester/providers/ollama_provider.py
+++ b/src/digester/providers/ollama_provider.py
@@ -141,4 +141,4 @@ class OllamaProvider(LLMProvider):
             system_prompt=build_finalize_system_prompt(),
             user_prompt=build_finalize_user_prompt(topics),
         )
-        return parse_finalized_topics(payload)
+        return parse_finalized_topics(payload, fallback_topics=topics)

--- a/src/digester/providers/openai_provider.py
+++ b/src/digester/providers/openai_provider.py
@@ -148,4 +148,4 @@ class OpenAIProvider(LLMProvider):
             system_prompt=build_finalize_system_prompt(),
             user_prompt=build_finalize_user_prompt(topics),
         )
-        return parse_finalized_topics(payload)
+        return parse_finalized_topics(payload, fallback_topics=topics)

--- a/src/digester/providers/parsing.py
+++ b/src/digester/providers/parsing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Sequence
+from typing import Dict, List, Optional, Sequence
 
 from ..core.models import DigestDecision, SourceRef, TopicDigest
 
@@ -12,27 +12,44 @@ def parse_digest_decision(
     return DigestDecision.from_payload(payload, fallback_refs=fallback_refs)
 
 
-def parse_finalized_topics(payload: Dict[str, object]) -> List[TopicDigest]:
+def _parse_source_refs(raw_refs: object) -> List[SourceRef]:
+    refs = []
+    if not isinstance(raw_refs, list):
+        return refs
+    for raw_ref in raw_refs:
+        if not isinstance(raw_ref, dict):
+            continue
+        source_id = str(raw_ref.get("source_id", "")).strip()
+        source_path = str(raw_ref.get("source_path", "")).strip()
+        locator = str(raw_ref.get("locator", "")).strip()
+        if source_id and source_path and locator:
+            refs.append(SourceRef(source_id=source_id, source_path=source_path, locator=locator))
+    return refs
+
+
+def parse_finalized_topics(
+    payload: Dict[str, object],
+    fallback_topics: Optional[Sequence[TopicDigest]] = None,
+) -> List[TopicDigest]:
     finalized = payload.get("topics")
     if not isinstance(finalized, list):
         raise ValueError("Finalized topic payload must contain a topics list.")
 
+    fallback_refs_by_slug = {
+        topic.slug: list(topic.references)
+        for topic in fallback_topics or []
+    }
     result: List[TopicDigest] = []
     for raw_topic in finalized:
         if not isinstance(raw_topic, dict):
             continue
-        refs = []
-        for raw_ref in raw_topic.get("references", []):
-            if not isinstance(raw_ref, dict):
-                continue
-            source_id = str(raw_ref.get("source_id", "")).strip()
-            source_path = str(raw_ref.get("source_path", "")).strip()
-            locator = str(raw_ref.get("locator", "")).strip()
-            if source_id and source_path and locator:
-                refs.append(SourceRef(source_id=source_id, source_path=source_path, locator=locator))
+        slug = str(raw_topic.get("slug", "")).strip()
+        refs = _parse_source_refs(raw_topic.get("references", []))
+        if not refs:
+            refs = fallback_refs_by_slug.get(slug, [])
         result.append(
             TopicDigest(
-                slug=str(raw_topic.get("slug", "")).strip(),
+                slug=slug,
                 title=str(raw_topic.get("title", "")).strip(),
                 routing_description=str(
                     raw_topic.get("routing_description") or raw_topic.get("when_to_use") or ""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,3 +1,5 @@
+import json
+
 from digester.core import DigestConfig
 from digester.core.models import ContentChunk, DigestBatchRequest, SourceRef, TopicDigest
 from digester.core.prompts import (
@@ -75,3 +77,14 @@ def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
     assert "Expand weak summaries" in user_prompt
     assert "Make routing_description strong enough" in user_prompt
     assert "setup flow, operational nuance, and important edge cases" in user_prompt
+    assert '"source_id": "setup-guide"' in user_prompt
+    assert '"source_path": "/tmp/setup-guide.txt"' in user_prompt
+    assert '"locator": "section 2"' in user_prompt
+    payload = json.loads(user_prompt[user_prompt.index("[") :])
+    assert payload[0]["references"] == [
+        {
+            "source_id": "setup-guide",
+            "source_path": "/tmp/setup-guide.txt",
+            "locator": "section 2",
+        }
+    ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -301,6 +301,42 @@ def test_parse_finalized_topics_preserves_structured_skill_fields() -> None:
     ]
 
 
+def test_parse_finalized_topics_restores_missing_references_from_fallback_topic() -> None:
+    fallback_ref = SourceRef(
+        source_id="source",
+        source_path="/tmp/source.txt",
+        locator="full-document",
+    )
+
+    parsed = parse_finalized_topics(
+        {
+            "topics": [
+                {
+                    "slug": "overview",
+                    "title": "Overview",
+                    "routing_description": "Use this skill when reviewing the finalized overview guidance.",
+                    "summary": "Condenses the finalized source into reusable implementation guidance.",
+                    "key_points": ["Check the finalized guidance before editing."],
+                    "workflow_notes": ["Validate the cited source before applying the workflow."],
+                    "references": [],
+                }
+            ]
+        },
+        fallback_topics=[
+            TopicDigest(
+                slug="overview",
+                title="Overview",
+                routing_description="Use this skill when reviewing the draft overview guidance.",
+                summary="Draft summary",
+                key_points=[],
+                references=[fallback_ref],
+            )
+        ],
+    )
+
+    assert parsed[0].references == [fallback_ref]
+
+
 def test_parse_finalized_topics_treats_null_routing_description_as_empty_string() -> None:
     parsed = parse_finalized_topics(
         {


### PR DESCRIPTION
## Summary
- send structured source reference objects in digest and finalize prompts
- restore topic references from fallback topics when finalized provider payloads omit them
- add regression coverage for structured prompt payloads and reference restoration

## Testing
- PYTHONPATH=src .venv/bin/pytest -q