### PR TITLE
Improve DOCX embedded image reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Each agent root also includes a short `INSTALL.md` that lists the documented pro
 - DOCX (with optional embedded image analysis)
 - XLSX/XLSM
 
+## External tool requirements
+
+Bookworm's Python package dependencies are installed from `pyproject.toml`. Some embedded DOCX image cases also depend on optional system tools:
+
+- Ollama image analysis requires an Ollama server that supports `/api/chat` image payloads and a vision-capable model.
+- DOCX images stored as EMF/WMF previews are converted to PNG before vision analysis. Install Inkscape when you need these legacy/vector previews analyzed.
+- Supported Inkscape CLIs:
+  - Inkscape 0.92.x style: `inkscape --without-gui input.emf --export-png=output.png`
+  - Inkscape 1.x style: `inkscape input.emf --export-type=png --export-filename=output.png`
+- ImageMagick is used only as a fallback (`magick` or `convert`). ImageMagick 6/7 must be built with an EMF/WMF-capable delegate for these previews; many Linux builds cannot decode EMF by default.
+
 ## Provider model
 
 - `openai`: hosted OpenAI models
@@ -122,6 +133,8 @@ bookworm digest docs/*.docx \
 ```
 
 Use `--image-analyzer-kind openai-compatible` to point image analysis at an OpenAI-compatible vision endpoint, or `--image-analyzer-kind mock-image` for deterministic test fixtures without a live model. If no image analyzer is configured, Bookworm keeps the existing text-only path and logs when supported inputs contain embedded images that were skipped.
+
+If a DOCX contains only an embedded EMF/WMF preview, install Inkscape so Bookworm can convert the preview to PNG before sending it to the vision model. Without a working converter, the image is skipped with a warning because most vision APIs reject EMF/WMF bytes directly.
 
 After a successful run, the CLI prints a short status report to stdout with the chunk count, configured and realized batch sizes, total chunk chars, batch count, elapsed digestion time, and generated skill count.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -369,11 +369,15 @@ All non-LLM behaviors such as file loading, chunking, adapter routing, and markd
 
 ### 17.2 Dependencies
 
-- `openai`
-- `pypdf`
-- `python-docx`
-- `openpyxl`
-- `pytest` for development
+- Python package dependencies:
+  - `openai>=1.30.0`
+  - `pypdf>=4.2.0`
+  - `python-docx>=1.1.0`
+  - `openpyxl>=3.1.2`
+  - `pytest>=8.2.0` for development
+- Optional system tools for embedded DOCX image analysis:
+  - Inkscape for EMF/WMF preview conversion to PNG. Both 0.92.x-style `--export-png` and 1.x-style `--export-type=png --export-filename=...` CLIs are supported.
+  - ImageMagick 6/7 as a fallback through `magick` or `convert`, only when the local build includes an EMF/WMF-capable delegate.
 
 ### 17.3 Environment
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -533,6 +533,8 @@ Current error behavior is intentionally explicit:
 
 This keeps failures visible instead of silently generating misleading output.
 
+Embedded DOCX image analysis has one additional external-tool dependency: EMF/WMF previews must be converted to PNG before they are sent to vision providers. The DOCX adapter prefers Inkscape and supports both legacy `--export-png` and newer `--export-type=png --export-filename=...` CLIs. ImageMagick `magick` or `convert` is a fallback only when the local build can decode EMF/WMF. If conversion is unavailable or fails, the image is skipped with an extraction warning instead of sending unsupported bytes to the model.
+
 ## 13. Testing Strategy
 
 The current test suite covers:
@@ -550,11 +552,12 @@ The tests intentionally use fake providers for determinism and speed while prese
 
 1. No OCR support for scanned PDFs or image-heavy inputs
 2. No legacy `.doc` parser
-3. No tokenizer-aware chunk budgeting
-4. No retry/backoff or rate-limit handling in provider calls
-5. No persisted run metadata beyond generated markdown files
-6. No streaming or parallel digestion
-7. No confidence scoring or coverage reporting per topic
+3. EMF/WMF DOCX previews require a working Inkscape or EMF/WMF-capable ImageMagick installation for vision analysis
+4. No tokenizer-aware chunk budgeting
+5. No retry/backoff or rate-limit handling in provider calls
+6. No persisted run metadata beyond generated markdown files
+7. No streaming or parallel digestion
+8. No confidence scoring or coverage reporting per topic
 
 ## 15. Extension Roadmap
 

--- a/src/digester/core/models.py
+++ b/src/digester/core/models.py
@@ -103,6 +103,7 @@ class SourceDocument:
     title: str
     sections: List[DocumentSection]
     embedded_images: List[EmbeddedImage] = field(default_factory=list)
+    extraction_notes: List[str] = field(default_factory=list)
     extraction_warnings: List[str] = field(default_factory=list)
 
     @property

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -17,6 +17,29 @@ from .models import (
 )
 
 
+def _no_extractable_content_error(documents: List[SourceDocument]) -> str:
+    embedded_image_count = sum(len(document.embedded_images) for document in documents)
+    warnings = [
+        warning
+        for document in documents
+        for warning in document.extraction_warnings
+    ]
+    if embedded_image_count:
+        details = [
+            "No extractable text was found in the supplied inputs.",
+            "Detected {count} embedded image(s), but no image-analysis content was available.".format(
+                count=embedded_image_count
+            ),
+        ]
+        if warnings:
+            details.append("Warnings: {warnings}".format(warnings="; ".join(warnings)))
+        details.append(
+            "For image-only DOCX files, configure a vision analyzer such as --image-analyzer-kind ollama."
+        )
+        return " ".join(details)
+    return "No extractable text was found in the supplied inputs."
+
+
 class DigestOrchestrator:
     def __init__(
         self,
@@ -39,7 +62,7 @@ class DigestOrchestrator:
         )
         chunks = chunk_documents(documents, max_chunk_chars=self.config.max_chunk_chars)
         if not chunks:
-            raise ValueError("No extractable text was found in the supplied inputs.")
+            raise ValueError(_no_extractable_content_error(documents))
 
         self.progress_reporter.persist(
             "Prepared {chunks} chunk(s) from {documents} document(s).".format(

--- a/src/digester/images/ollama_image_analyzer.py
+++ b/src/digester/images/ollama_image_analyzer.py
@@ -47,6 +47,19 @@ class OllamaImageAnalyzer(ImageAnalyzer):
         system_prompt = _build_image_system_prompt()
         user_prompt = _build_image_user_prompt(image)
         self._log_helper._log_request("Ollama image analyzer", self.model, system_prompt, user_prompt)
+        encoded_image = base64.b64encode(image.data).decode("ascii")
+        self.progress_reporter.verbose(
+            (
+                "Verbose: attaching image payload to Ollama image analyzer request "
+                "({locator}; file={filename}; mime={mime_type}; bytes={byte_count}; base64_chars={encoded_chars})."
+            ).format(
+                locator=image.source_ref.locator,
+                filename=image.filename or "(unnamed)",
+                mime_type=image.mime_type or "application/octet-stream",
+                byte_count=len(image.data),
+                encoded_chars=len(encoded_image),
+            )
+        )
         payload = json.dumps(
             {
                 "model": self.model,
@@ -58,7 +71,7 @@ class OllamaImageAnalyzer(ImageAnalyzer):
                     {
                         "role": "user",
                         "content": user_prompt,
-                        "images": [base64.b64encode(image.data).decode("ascii")],
+                        "images": [encoded_image],
                     },
                 ],
             }

--- a/src/digester/sources/docx.py
+++ b/src/digester/sources/docx.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Tuple
 
 from docx import Document
 from docx.document import Document as DocxDocument
+from docx.oxml.table import CT_Tbl
+from docx.oxml.text.paragraph import CT_P
 from docx.table import Table
 from docx.text.paragraph import Paragraph
 
@@ -55,17 +57,14 @@ def _mime_type_for_filename(filename: str) -> str:
     return _MIME_TYPES_BY_SUFFIX.get(PurePosixPath(filename).suffix.lower(), "application/octet-stream")
 
 
-def _table_paragraphs(document: DocxDocument) -> List[Paragraph]:
-    paragraphs: List[Paragraph] = []
-    for table in document.tables:
-        paragraphs.extend(_paragraphs_from_table(table))
-    return paragraphs
-
-
 def _paragraphs_from_table(table: Table) -> List[Paragraph]:
     paragraphs: List[Paragraph] = []
+    seen_cells = set()
     for row in table.rows:
         for cell in row.cells:
+            if cell._tc in seen_cells:
+                continue
+            seen_cells.add(cell._tc)
             paragraphs.extend(cell.paragraphs)
             for nested_table in cell.tables:
                 paragraphs.extend(_paragraphs_from_table(nested_table))
@@ -74,10 +73,17 @@ def _paragraphs_from_table(table: Table) -> List[Paragraph]:
 
 def _document_paragraphs_with_locations(document: DocxDocument) -> List[Tuple[str, int, Paragraph]]:
     located: List[Tuple[str, int, Paragraph]] = []
-    for offset, paragraph in enumerate(document.paragraphs, start=1):
-        located.append(("paragraph", offset, paragraph))
-    for offset, paragraph in enumerate(_table_paragraphs(document), start=1):
-        located.append(("table paragraph", offset, paragraph))
+    paragraph_offset = 0
+    table_paragraph_offset = 0
+    for child in document.element.body.iterchildren():
+        if isinstance(child, CT_P):
+            paragraph_offset += 1
+            located.append(("paragraph", paragraph_offset, Paragraph(child, document)))
+            continue
+        if isinstance(child, CT_Tbl):
+            for paragraph in _paragraphs_from_table(Table(child, document)):
+                table_paragraph_offset += 1
+                located.append(("table paragraph", table_paragraph_offset, paragraph))
     return located
 
 

--- a/src/digester/sources/docx.py
+++ b/src/digester/sources/docx.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import tempfile
 from typing import List, Optional, Tuple
 
 from docx import Document
@@ -15,8 +19,11 @@ from ..images.base import ImageAnalyzer
 from .base import SourceAdapter
 
 _BLIP_TAG = ".//{http://schemas.openxmlformats.org/drawingml/2006/main}blip"
+_VML_IMAGE_TAG = ".//{urn:schemas-microsoft-com:vml}imagedata"
 _EMBED_ATTR = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed"
+_RELATIONSHIP_ID_ATTR = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"
 _MIME_TYPES_BY_SUFFIX = {
+    ".emf": "image/x-emf",
     ".gif": "image/gif",
     ".jpeg": "image/jpeg",
     ".jpg": "image/jpeg",
@@ -24,7 +31,10 @@ _MIME_TYPES_BY_SUFFIX = {
     ".tif": "image/tiff",
     ".tiff": "image/tiff",
     ".webp": "image/webp",
+    ".wmf": "image/x-wmf",
 }
+_VECTOR_IMAGE_SUFFIXES = {".emf", ".wmf"}
+_VECTOR_IMAGE_MIME_TYPES = {"image/emf", "image/x-emf", "image/wmf", "image/x-wmf"}
 
 
 def _nearest_non_empty_paragraph_text(
@@ -99,6 +109,19 @@ def _locator_for_image(image_index: int, location_kind: str, location_offset: in
     )
 
 
+def _image_relationship_ids(run) -> List[str]:
+    rel_ids: List[str] = []
+    for blip in run._element.findall(_BLIP_TAG):
+        rel_id = str(blip.get(_EMBED_ATTR, "")).strip()
+        if rel_id:
+            rel_ids.append(rel_id)
+    for image_data in run._element.findall(_VML_IMAGE_TAG):
+        rel_id = str(image_data.get(_RELATIONSHIP_ID_ATTR, "")).strip()
+        if rel_id:
+            rel_ids.append(rel_id)
+    return rel_ids
+
+
 def _extract_embedded_images(
     document: DocxDocument,
     source_id: str,
@@ -119,10 +142,7 @@ def _extract_embedded_images(
             )
         )
         for run in paragraph.runs:
-            for blip in run._element.findall(_BLIP_TAG):
-                rel_id = str(blip.get(_EMBED_ATTR, "")).strip()
-                if not rel_id:
-                    continue
+            for rel_id in _image_relationship_ids(run):
                 relationship = document.part.rels.get(rel_id)
                 image_part = document.part.related_parts.get(rel_id)
                 if relationship is None or image_part is None:
@@ -196,6 +216,101 @@ def _image_metadata_line(image: EmbeddedImage) -> str:
     )
 
 
+def _image_requires_png_normalization(image: EmbeddedImage) -> bool:
+    suffix = PurePosixPath(image.filename).suffix.lower()
+    return suffix in _VECTOR_IMAGE_SUFFIXES or image.mime_type.lower() in _VECTOR_IMAGE_MIME_TYPES
+
+
+def _image_converter_command(input_path: Path, output_path: Path) -> Optional[List[str]]:
+    inkscape = shutil.which("inkscape")
+    if inkscape:
+        try:
+            help_result = subprocess.run(
+                [inkscape, "--help"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            help_text = "{stdout}\n{stderr}".format(
+                stdout=help_result.stdout,
+                stderr=help_result.stderr,
+            )
+        except Exception:
+            help_text = ""
+        if "--export-png" in help_text:
+            return [inkscape, "--without-gui", str(input_path), "--export-png={output_path}".format(
+                output_path=output_path,
+            )]
+        return [
+            inkscape,
+            str(input_path),
+            "--export-type=png",
+            "--export-filename={output_path}".format(output_path=output_path),
+        ]
+    magick = shutil.which("magick")
+    if magick:
+        return [magick, str(input_path), str(output_path)]
+    convert = shutil.which("convert")
+    if convert:
+        return [convert, str(input_path), str(output_path)]
+    return None
+
+
+def _normalize_image_for_analysis(image: EmbeddedImage) -> Tuple[Optional[EmbeddedImage], str]:
+    if not _image_requires_png_normalization(image):
+        return image, ""
+    suffix = PurePosixPath(image.filename).suffix.lower() or ".img"
+    try:
+        with tempfile.TemporaryDirectory(prefix="bookworm-image-") as directory:
+            input_path = Path(directory) / "input{suffix}".format(suffix=suffix)
+            output_path = Path(directory) / "output.png"
+            input_path.write_bytes(image.data)
+            command = _image_converter_command(input_path=input_path, output_path=output_path)
+            if command is None:
+                return (
+                    None,
+                    (
+                        "Image {details} uses a vector preview format that most vision APIs cannot decode, "
+                        "and no Inkscape or ImageMagick converter was found."
+                    ).format(details=_image_metadata_line(image)),
+                )
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "converter exited with a non-zero status").strip()
+                return (
+                    None,
+                    "Unable to convert {details} to PNG: {detail}".format(
+                        details=_image_metadata_line(image),
+                        detail=detail,
+                    ),
+                )
+            converted_data = output_path.read_bytes()
+    except Exception as error:
+        return (
+            None,
+            "Unable to convert {details} to PNG: {error}".format(
+                details=_image_metadata_line(image),
+                error=error,
+            ),
+        )
+    converted_filename = "{stem}.png".format(stem=PurePosixPath(image.filename).stem or "image")
+    converted_image = replace(
+        image,
+        filename=converted_filename,
+        mime_type="image/png",
+        data=converted_data,
+    )
+    return converted_image, "Normalized embedded image for analysis: {original} -> {converted}.".format(
+        original=_image_metadata_line(image),
+        converted=_image_metadata_line(converted_image),
+    )
+
+
 class DocxAdapter(SourceAdapter):
     supported_suffixes = (".docx",)
     media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -238,19 +353,30 @@ class DocxAdapter(SourceAdapter):
             )
         if image_analyzer is not None:
             for index, image in enumerate(embedded_images, start=1):
+                analysis_image, normalization_message = _normalize_image_for_analysis(image)
+                if normalization_message and analysis_image is not None:
+                    notes.append(normalization_message)
+                if normalization_message and analysis_image is None:
+                    warnings.append(
+                        "Skipped embedded image {index}: {message}".format(
+                            index=index,
+                            message=normalization_message,
+                        )
+                    )
+                    continue
                 notes.append(
                     "Analyzing embedded image {index}: {details}.".format(
                         index=index,
-                        details=_image_metadata_line(image),
+                        details=_image_metadata_line(analysis_image),
                     )
                 )
                 try:
-                    analysis = image_analyzer.analyze(image)
+                    analysis = image_analyzer.analyze(analysis_image)
                     sections.append(
                         DocumentSection(
                             heading="Embedded image {index}".format(index=index),
-                            content=_render_image_analysis(image, analysis),
-                            source_ref=image.source_ref,
+                            content=_render_image_analysis(analysis_image, analysis),
+                            source_ref=analysis_image.source_ref,
                             content_kind="image-analysis",
                         )
                     )

--- a/src/digester/sources/docx.py
+++ b/src/digester/sources/docx.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path, PurePosixPath
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from docx import Document
 from docx.document import Document as DocxDocument
+from docx.table import Table
 from docx.text.paragraph import Paragraph
 
 from ..core.models import DocumentSection, EmbeddedImage, ImageAnalysis, SourceDocument, SourceRef
@@ -54,15 +55,54 @@ def _mime_type_for_filename(filename: str) -> str:
     return _MIME_TYPES_BY_SUFFIX.get(PurePosixPath(filename).suffix.lower(), "application/octet-stream")
 
 
+def _table_paragraphs(document: DocxDocument) -> List[Paragraph]:
+    paragraphs: List[Paragraph] = []
+    for table in document.tables:
+        paragraphs.extend(_paragraphs_from_table(table))
+    return paragraphs
+
+
+def _paragraphs_from_table(table: Table) -> List[Paragraph]:
+    paragraphs: List[Paragraph] = []
+    for row in table.rows:
+        for cell in row.cells:
+            paragraphs.extend(cell.paragraphs)
+            for nested_table in cell.tables:
+                paragraphs.extend(_paragraphs_from_table(nested_table))
+    return paragraphs
+
+
+def _document_paragraphs_with_locations(document: DocxDocument) -> List[Tuple[str, int, Paragraph]]:
+    located: List[Tuple[str, int, Paragraph]] = []
+    for offset, paragraph in enumerate(document.paragraphs, start=1):
+        located.append(("paragraph", offset, paragraph))
+    for offset, paragraph in enumerate(_table_paragraphs(document), start=1):
+        located.append(("table paragraph", offset, paragraph))
+    return located
+
+
+def _locator_for_image(image_index: int, location_kind: str, location_offset: int) -> str:
+    if location_kind == "table paragraph":
+        return "embedded image {index} near table paragraph {paragraph}".format(
+            index=image_index,
+            paragraph=location_offset,
+        )
+    return "embedded image {index} near paragraph {paragraph}".format(
+        index=image_index,
+        paragraph=location_offset,
+    )
+
+
 def _extract_embedded_images(
     document: DocxDocument,
     source_id: str,
     path: Path,
 ) -> List[EmbeddedImage]:
-    paragraphs = list(document.paragraphs)
+    located_paragraphs = _document_paragraphs_with_locations(document)
+    paragraphs = [paragraph for _, _, paragraph in located_paragraphs]
     images: List[EmbeddedImage] = []
     image_index = 1
-    for paragraph_offset, paragraph in enumerate(paragraphs):
+    for paragraph_offset, (location_kind, location_number, paragraph) in enumerate(located_paragraphs):
         caption = paragraph.text.strip()
         nearby_context = "\n".join(
             _dedupe_non_empty(
@@ -91,10 +131,7 @@ def _extract_embedded_images(
                         source_ref=SourceRef(
                             source_id=source_id,
                             source_path=str(path),
-                            locator="embedded image {index} near paragraph {paragraph}".format(
-                                index=image_index,
-                                paragraph=paragraph_offset + 1,
-                            ),
+                            locator=_locator_for_image(image_index, location_kind, location_number),
                         ),
                         filename=filename or "image-{index}".format(index=image_index),
                         mime_type=getattr(image_part, "content_type", "")
@@ -142,6 +179,17 @@ def _render_image_analysis(image: EmbeddedImage, analysis: ImageAnalysis) -> str
     return "\n".join(lines)
 
 
+def _image_metadata_line(image: EmbeddedImage) -> str:
+    return (
+        "{locator}: file={filename}, mime={mime_type}, bytes={byte_count}"
+    ).format(
+        locator=image.source_ref.locator,
+        filename=image.filename or "(unnamed)",
+        mime_type=image.mime_type or "application/octet-stream",
+        byte_count=len(image.data),
+    )
+
+
 class DocxAdapter(SourceAdapter):
     supported_suffixes = (".docx",)
     media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -168,7 +216,15 @@ class DocxAdapter(SourceAdapter):
                 )
             )
         embedded_images = _extract_embedded_images(document=document, source_id=source_id, path=path)
+        notes: List[str] = []
         warnings: List[str] = []
+        if embedded_images:
+            notes.append(
+                "Detected {count} embedded image(s): {details}.".format(
+                    count=len(embedded_images),
+                    details="; ".join(_image_metadata_line(image) for image in embedded_images),
+                )
+            )
         if embedded_images and image_analyzer is None:
             warnings.append(
                 "Detected {count} embedded image(s) but no image analyzer is configured; image content was skipped."
@@ -176,6 +232,12 @@ class DocxAdapter(SourceAdapter):
             )
         if image_analyzer is not None:
             for index, image in enumerate(embedded_images, start=1):
+                notes.append(
+                    "Analyzing embedded image {index}: {details}.".format(
+                        index=index,
+                        details=_image_metadata_line(image),
+                    )
+                )
                 try:
                     analysis = image_analyzer.analyze(image)
                     sections.append(
@@ -185,6 +247,9 @@ class DocxAdapter(SourceAdapter):
                             source_ref=image.source_ref,
                             content_kind="image-analysis",
                         )
+                    )
+                    notes.append(
+                        "Analyzed embedded image {index} successfully.".format(index=index)
                     )
                 except Exception as error:
                     warnings.append(
@@ -200,5 +265,6 @@ class DocxAdapter(SourceAdapter):
             title=path.stem,
             sections=sections,
             embedded_images=embedded_images,
+            extraction_notes=notes,
             extraction_warnings=warnings,
         )

--- a/src/digester/sources/registry.py
+++ b/src/digester/sources/registry.py
@@ -60,6 +60,13 @@ class SourceRegistry:
                     sections=len(document.sections),
                 )
             )
+            for note in document.extraction_notes:
+                reporter.persist(
+                    "Note for {name}: {note}".format(
+                        name=file_label(path),
+                        note=note,
+                    )
+                )
             for warning in document.extraction_warnings:
                 reporter.persist(
                     "Warning for {name}: {warning}".format(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -178,6 +178,13 @@ def test_ollama_image_analyzer_verbose_logging_includes_model_response(monkeypat
 
     verbose_messages = [message for kind, message in reporter.messages if kind == "verbose"]
     assert any("request preview" in message and "--- system ---" in message for message in verbose_messages)
+    assert any(
+        "attaching image payload" in message
+        and "embedded image 1 near paragraph 2" in message
+        and "bytes=11" in message
+        and "base64_chars=16" in message
+        for message in verbose_messages
+    )
     assert any("response preview" in message and "setup wizard confirmation dialog" in message for message in verbose_messages)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -80,6 +80,14 @@ def _write_docx_with_embedded_image(path: Path) -> None:
     document.save(path)
 
 
+def _write_docx_with_only_embedded_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    document = Document()
+    document.add_picture(str(image_path))
+    document.save(path)
+
+
 def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
     input_path = tmp_path / "source.txt"
     input_path.write_text(
@@ -555,3 +563,37 @@ def test_document_digester_includes_embedded_image_analysis_in_topic_output(tmp_
     assert "Visual summary:" in skill_text
     assert "Screenshot shows the confirmation dialog" in skill_text
     assert "embedded image 1 near paragraph 2" in skill_text
+
+
+def test_document_digester_processes_image_only_docx_with_analyzer(tmp_path: Path) -> None:
+    input_path = tmp_path / "image-only.docx"
+    _write_docx_with_only_embedded_image(input_path)
+    output_dir = tmp_path / "out"
+
+    result = DocumentDigester(
+        provider=ImageEchoProvider(),
+        image_analyzer=MockImageAnalyzer(model="fake-vision"),
+        config=DigestConfig(max_chunk_chars=400, batch_size=2, minimum_batches_before_stop=1),
+    ).digest_paths([input_path], output_dir)
+
+    assert len(result.documents[0].sections) == 1
+    assert result.documents[0].sections[0].content_kind == "image-analysis"
+    assert result.chunks
+    assert all(chunk.content_kind == "image-analysis" for chunk in result.chunks)
+    assert any("Visual summary:" in chunk.text for chunk in result.chunks)
+
+
+def test_document_digester_reports_missing_analyzer_for_image_only_docx(tmp_path: Path) -> None:
+    input_path = tmp_path / "image-only.docx"
+    _write_docx_with_only_embedded_image(input_path)
+
+    with pytest.raises(ValueError) as error:
+        DocumentDigester(
+            provider=ImageEchoProvider(),
+            config=DigestConfig(max_chunk_chars=400, batch_size=2, minimum_batches_before_stop=1),
+        ).digest_paths([input_path], tmp_path / "out")
+
+    message = str(error.value)
+    assert "No extractable text was found in the supplied inputs." in message
+    assert "Detected 1 embedded image(s), but no image-analysis content was available." in message
+    assert "--image-analyzer-kind ollama" in message

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -27,6 +27,39 @@ def _write_docx_with_embedded_image(path: Path) -> None:
     document.save(path)
 
 
+def _write_docx_with_table_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    document = Document()
+    document.add_paragraph("Before table")
+    table = document.add_table(rows=1, cols=1)
+    image_paragraph = table.cell(0, 0).paragraphs[0]
+    image_paragraph.text = "Screenshot in a table cell"
+    image_paragraph.add_run().add_picture(str(image_path))
+    document.add_paragraph("After table")
+    document.save(path)
+
+
+class RecordingReporter:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def update(self, message: str) -> None:
+        self.messages.append(("update", message))
+
+    def persist(self, message: str) -> None:
+        self.messages.append(("persist", message))
+
+    def verbose(self, message: str) -> None:
+        self.messages.append(("verbose", message))
+
+    def verbosity(self) -> int:
+        return 0
+
+    def clear(self) -> None:
+        self.messages.append(("clear", ""))
+
+
 def test_registry_loads_plain_text(tmp_path: Path) -> None:
     path = tmp_path / "notes.txt"
     path.write_text("alpha\n\nbeta", encoding="utf-8")
@@ -73,6 +106,14 @@ def test_registry_detects_docx_embedded_images_without_analyzer(tmp_path: Path) 
     assert len(documents[0].embedded_images) == 1
     assert documents[0].embedded_images[0].caption == "Screenshot shows the confirmation dialog"
     assert documents[0].embedded_images[0].source_ref.locator == "embedded image 1 near paragraph 2"
+    assert documents[0].embedded_images[0].mime_type == "image/png"
+    assert len(documents[0].embedded_images[0].data) > 0
+    assert documents[0].extraction_notes == [
+        (
+            "Detected 1 embedded image(s): embedded image 1 near paragraph 2: "
+            "file=image1.png, mime=image/png, bytes=68."
+        )
+    ]
     assert documents[0].extraction_warnings == [
         "Detected 1 embedded image(s) but no image analyzer is configured; image content was skipped."
     ]
@@ -91,7 +132,59 @@ def test_registry_loads_docx_embedded_images_with_analyzer(tmp_path: Path) -> No
     assert image_section.source_ref.locator == "embedded image 1 near paragraph 2"
     assert "Visual summary:" in image_section.content
     assert "Screenshot shows the confirmation dialog" in image_section.content
+    assert documents[0].extraction_notes == [
+        (
+            "Detected 1 embedded image(s): embedded image 1 near paragraph 2: "
+            "file=image1.png, mime=image/png, bytes=68."
+        ),
+        (
+            "Analyzing embedded image 1: embedded image 1 near paragraph 2: "
+            "file=image1.png, mime=image/png, bytes=68."
+        ),
+        "Analyzed embedded image 1 successfully.",
+    ]
     assert documents[0].extraction_warnings == []
+
+
+def test_registry_detects_docx_embedded_images_inside_tables(tmp_path: Path) -> None:
+    path = tmp_path / "with-table-image.docx"
+    _write_docx_with_table_image(path)
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=MockImageAnalyzer(model="fake-vision"))
+
+    assert len(documents[0].embedded_images) == 1
+    assert documents[0].embedded_images[0].caption == "Screenshot in a table cell"
+    assert documents[0].embedded_images[0].source_ref.locator == "embedded image 1 near table paragraph 1"
+    assert documents[0].embedded_images[0].mime_type == "image/png"
+    assert len(documents[0].embedded_images[0].data) > 0
+    assert len(documents[0].sections) == 2
+    image_section = documents[0].sections[1]
+    assert image_section.content_kind == "image-analysis"
+    assert "Screenshot in a table cell" in image_section.content
+    assert documents[0].extraction_warnings == []
+
+
+def test_registry_logs_docx_embedded_image_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "with-image.docx"
+    _write_docx_with_embedded_image(path)
+    reporter = RecordingReporter()
+
+    SourceRegistry().load_paths([path], progress_reporter=reporter)
+
+    persisted = [message for kind, message in reporter.messages if kind == "persist"]
+    assert any(
+        message.startswith("Note for with-image.docx: Detected 1 embedded image(s): ")
+        and "embedded image 1 near paragraph 2" in message
+        and "file=image1.png, mime=image/png, bytes=68" in message
+        for message in persisted
+    )
+    assert any(
+        message == (
+            "Warning for with-image.docx: "
+            "Detected 1 embedded image(s) but no image analyzer is configured; image content was skipped."
+        )
+        for message in persisted
+    )
 
 
 class FailingImageAnalyzer(ImageAnalyzer):
@@ -110,6 +203,16 @@ def test_registry_keeps_docx_text_when_embedded_image_analysis_fails(tmp_path: P
         "Before image\n\nScreenshot shows the confirmation dialog\n\nAfter image"
     )
     assert documents[0].embedded_images[0].source_ref.locator == "embedded image 1 near paragraph 2"
+    assert documents[0].extraction_notes == [
+        (
+            "Detected 1 embedded image(s): embedded image 1 near paragraph 2: "
+            "file=image1.png, mime=image/png, bytes=68."
+        ),
+        (
+            "Analyzing embedded image 1: embedded image 1 near paragraph 2: "
+            "file=image1.png, mime=image/png, bytes=68."
+        ),
+    ]
     assert documents[0].extraction_warnings == [
         "Failed to analyze embedded image 1: vision request timed out"
     ]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,12 +1,15 @@
 from base64 import b64decode
 from pathlib import Path
+import re
+from types import SimpleNamespace
+from zipfile import ZIP_DEFLATED, ZipFile
 
 from docx import Document
 from openpyxl import Workbook
 
 from digester.images import MockImageAnalyzer
 from digester.images.base import ImageAnalyzer
-from digester.core.models import EmbeddedImage
+from digester.core.models import EmbeddedImage, ImageAnalysis
 from digester.sources.registry import SourceRegistry
 
 
@@ -52,6 +55,64 @@ def _write_docx_with_merged_table_image(path: Path) -> None:
     document.save(path)
 
 
+def _write_docx_with_vml_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    document = Document()
+    document.add_picture(str(image_path))
+    document.save(path)
+
+    with ZipFile(path, "r") as source:
+        document_xml = source.read("word/document.xml").decode("utf-8")
+        match = re.search(r'r:embed="([^"]+)"', document_xml)
+        assert match is not None
+        rel_id = match.group(1)
+        vml_object = (
+            '<w:object><v:shape id="_x0000_i1025" type="#_x0000_t75">'
+            '<v:imagedata r:id="{rel_id}"/></v:shape></w:object>'
+        ).format(rel_id=rel_id)
+        document_xml = re.sub(
+            r"<w:drawing>.*?</w:drawing>",
+            vml_object,
+            document_xml,
+            count=1,
+            flags=re.DOTALL,
+        )
+        rewritten = path.with_suffix(".vml.docx")
+        with ZipFile(rewritten, "w", ZIP_DEFLATED) as target:
+            for item in source.infolist():
+                data = source.read(item.filename)
+                if item.filename == "word/document.xml":
+                    data = document_xml.encode("utf-8")
+                target.writestr(item, data)
+    rewritten.replace(path)
+
+
+def _write_docx_with_vml_vector_image(path: Path) -> None:
+    _write_docx_with_vml_image(path)
+    with ZipFile(path, "r") as source:
+        content_types = source.read("[Content_Types].xml").decode("utf-8")
+        content_types = content_types.replace(
+            "</Types>",
+            '<Default Extension="emf" ContentType="image/x-emf"/></Types>',
+        )
+        document_rels = source.read("word/_rels/document.xml.rels").decode("utf-8")
+        document_rels = document_rels.replace("media/image1.png", "media/image1.emf")
+        rewritten = path.with_suffix(".vector.docx")
+        with ZipFile(rewritten, "w", ZIP_DEFLATED) as target:
+            for item in source.infolist():
+                if item.filename == "word/media/image1.png":
+                    continue
+                data = source.read(item.filename)
+                if item.filename == "[Content_Types].xml":
+                    data = content_types.encode("utf-8")
+                if item.filename == "word/_rels/document.xml.rels":
+                    data = document_rels.encode("utf-8")
+                target.writestr(item, data)
+            target.writestr("word/media/image1.emf", source.read("word/media/image1.png"))
+    rewritten.replace(path)
+
+
 class RecordingReporter:
     def __init__(self) -> None:
         self.messages = []
@@ -70,6 +131,16 @@ class RecordingReporter:
 
     def clear(self) -> None:
         self.messages.append(("clear", ""))
+
+
+class CapturingImageAnalyzer(ImageAnalyzer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.images = []
+
+    def analyze(self, image: EmbeddedImage) -> ImageAnalysis:
+        self.images.append(image)
+        return ImageAnalysis(summary="Converted image was analyzed.", key_points=[])
 
 
 def test_registry_loads_plain_text(tmp_path: Path) -> None:
@@ -187,6 +258,109 @@ def test_registry_deduplicates_docx_embedded_images_inside_merged_table_cells(tm
     assert documents[0].embedded_images[0].caption == "Screenshot in a merged table cell"
     assert len([section for section in documents[0].sections if section.content_kind == "image-analysis"]) == 1
     assert documents[0].extraction_warnings == []
+
+
+def test_registry_detects_docx_vml_embedded_images(tmp_path: Path) -> None:
+    path = tmp_path / "with-vml-image.docx"
+    _write_docx_with_vml_image(path)
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=MockImageAnalyzer(model="fake-vision"))
+
+    assert len(documents[0].embedded_images) == 1
+    assert documents[0].embedded_images[0].source_ref.locator == "embedded image 1 near paragraph 1"
+    assert documents[0].embedded_images[0].filename == "image1.png"
+    assert documents[0].embedded_images[0].mime_type == "image/png"
+    assert len(documents[0].embedded_images[0].data) > 0
+    assert len(documents[0].sections) == 1
+    assert documents[0].sections[0].content_kind == "image-analysis"
+    assert "Visual summary:" in documents[0].sections[0].content
+    assert documents[0].extraction_warnings == []
+
+
+def test_registry_normalizes_vector_docx_images_before_analysis(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "with-vector-image.docx"
+    _write_docx_with_vml_vector_image(path)
+    analyzer = CapturingImageAnalyzer()
+
+    def fake_run(command, capture_output, text, timeout):
+        output_path = Path(command[-1].split("=", 1)[1])
+        _write_test_png(output_path)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "digester.sources.docx._image_converter_command",
+        lambda input_path, output_path: [
+            "fake-inkscape",
+            str(input_path),
+            "--export-type=png",
+            "--export-filename={output_path}".format(output_path=output_path),
+        ],
+    )
+    monkeypatch.setattr("digester.sources.docx.subprocess.run", fake_run)
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=analyzer)
+
+    assert len(analyzer.images) == 1
+    assert analyzer.images[0].filename == "image1.png"
+    assert analyzer.images[0].mime_type == "image/png"
+    assert analyzer.images[0].data.startswith(b"\x89PNG")
+    assert any("Normalized embedded image for analysis" in note for note in documents[0].extraction_notes)
+    assert documents[0].extraction_warnings == []
+
+
+def test_registry_supports_legacy_inkscape_vector_conversion(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "with-vector-image.docx"
+    _write_docx_with_vml_vector_image(path)
+    analyzer = CapturingImageAnalyzer()
+
+    def fake_run(command, capture_output, text, timeout):
+        if command == ["fake-inkscape", "--help"]:
+            return SimpleNamespace(returncode=0, stdout="  -e, --export-png=FILENAME", stderr="")
+        output_arg = [part for part in command if part.startswith("--export-png=")][0]
+        output_path = Path(output_arg.split("=", 1)[1])
+        _write_test_png(output_path)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("digester.sources.docx.shutil.which", lambda name: "fake-inkscape" if name == "inkscape" else None)
+    monkeypatch.setattr("digester.sources.docx.subprocess.run", fake_run)
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=analyzer)
+
+    assert len(analyzer.images) == 1
+    assert analyzer.images[0].mime_type == "image/png"
+    assert documents[0].extraction_warnings == []
+
+
+def test_registry_skips_vector_docx_images_when_normalization_fails(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "with-vector-image.docx"
+    _write_docx_with_vml_vector_image(path)
+    analyzer = CapturingImageAnalyzer()
+
+    monkeypatch.setattr(
+        "digester.sources.docx._image_converter_command",
+        lambda input_path, output_path: ["fake-convert", str(input_path), str(output_path)],
+    )
+    monkeypatch.setattr(
+        "digester.sources.docx.subprocess.run",
+        lambda command, capture_output, text, timeout: SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="no decode delegate for this image format `EMF'",
+        ),
+    )
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=analyzer)
+
+    assert analyzer.images == []
+    assert documents[0].sections == []
+    assert len(documents[0].embedded_images) == 1
+    assert documents[0].extraction_warnings == [
+        (
+            "Skipped embedded image 1: Unable to convert embedded image 1 near paragraph 1: "
+            "file=image1.emf, mime=image/x-emf, bytes=68 to PNG: "
+            "no decode delegate for this image format `EMF'"
+        )
+    ]
 
 
 def test_registry_logs_docx_embedded_image_metadata(tmp_path: Path) -> None:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -40,6 +40,18 @@ def _write_docx_with_table_image(path: Path) -> None:
     document.save(path)
 
 
+def _write_docx_with_merged_table_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    document = Document()
+    table = document.add_table(rows=1, cols=2)
+    merged_cell = table.cell(0, 0).merge(table.cell(0, 1))
+    image_paragraph = merged_cell.paragraphs[0]
+    image_paragraph.text = "Screenshot in a merged table cell"
+    image_paragraph.add_run().add_picture(str(image_path))
+    document.save(path)
+
+
 class RecordingReporter:
     def __init__(self) -> None:
         self.messages = []
@@ -155,12 +167,25 @@ def test_registry_detects_docx_embedded_images_inside_tables(tmp_path: Path) -> 
     assert len(documents[0].embedded_images) == 1
     assert documents[0].embedded_images[0].caption == "Screenshot in a table cell"
     assert documents[0].embedded_images[0].source_ref.locator == "embedded image 1 near table paragraph 1"
+    assert documents[0].embedded_images[0].context_text == "Before table\nAfter table"
     assert documents[0].embedded_images[0].mime_type == "image/png"
     assert len(documents[0].embedded_images[0].data) > 0
     assert len(documents[0].sections) == 2
     image_section = documents[0].sections[1]
     assert image_section.content_kind == "image-analysis"
     assert "Screenshot in a table cell" in image_section.content
+    assert documents[0].extraction_warnings == []
+
+
+def test_registry_deduplicates_docx_embedded_images_inside_merged_table_cells(tmp_path: Path) -> None:
+    path = tmp_path / "with-merged-table-image.docx"
+    _write_docx_with_merged_table_image(path)
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=MockImageAnalyzer(model="fake-vision"))
+
+    assert len(documents[0].embedded_images) == 1
+    assert documents[0].embedded_images[0].caption == "Screenshot in a merged table cell"
+    assert len([section for section in documents[0].sections if section.content_kind == "image-analysis"]) == 1
     assert documents[0].extraction_warnings == []
 
 


### PR DESCRIPTION
## What changed
- Adds extraction notes for DOCX embedded images and persists them through the source registry.
- Detects embedded images that live inside tables, not just regular paragraphs.
- Improves image-analysis logging with filename, MIME type, byte count, and payload details for Ollama requests.
- Adds tests covering table images, metadata logging, and analyzer verbose output.

## Validation
- PYTHONPATH=src .venv/bin/pytest -q