### PR TITLE
Analyze embedded images in PDF and XLSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Each agent root also includes a short `INSTALL.md` that lists the documented pro
 
 - Plain text and markdown
 - PDF
-- DOCX (with optional embedded image analysis)
+- DOCX
 - XLSX/XLSM
 
 ## External tool requirements
 
-Bookworm's Python package dependencies are installed from `pyproject.toml`. Some embedded DOCX image cases also depend on optional system tools:
+Bookworm's Python package dependencies are installed from `pyproject.toml`. Embedded PDF, DOCX, and spreadsheet image extraction relies on Pillow, which is installed with the package. Some embedded image cases also depend on optional system tools:
 
 - Ollama image analysis requires an Ollama server that supports `/api/chat` image payloads and a vision-capable model.
 - DOCX images stored as EMF/WMF previews are converted to PNG before vision analysis. Install Inkscape when you need these legacy/vector previews analyzed.
@@ -110,10 +110,10 @@ bookworm digest docs/*.txt \
 
 ## Embedded image analysis
 
-Bookworm can optionally analyze embedded DOCX images and feed the resulting evidence back into the normal topic discovery flow as source-backed chunks.
+Bookworm can optionally analyze embedded images from supported PDF, DOCX, XLSX, and XLSM sources and feed the resulting evidence back into the normal topic discovery flow as source-backed chunks.
 
 ```bash
-bookworm digest docs/*.docx \
+bookworm digest docs/*.{pdf,docx,xlsx,xlsm} \
   --output-dir out \
   --provider-kind openai \
   --model gpt-4.1-mini \

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Use `--image-analyzer-kind openai-compatible` to point image analysis at an Open
 
 If a DOCX contains only an embedded EMF/WMF preview, install Inkscape so Bookworm can convert the preview to PNG before sending it to the vision model. Without a working converter, the image is skipped with a warning because most vision APIs reject EMF/WMF bytes directly.
 
+Spreadsheet image extraction requires loading XLSX/XLSM workbooks in normal mode rather than `read_only=True`, so very large spreadsheets with embedded images can use more memory than text-only ingestion.
+
 After a successful run, the CLI prints a short status report to stdout with the chunk count, configured and realized batch sizes, total chunk chars, batch count, elapsed digestion time, and generated skill count.
 
 ## Loop semantics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.8"
 dependencies = [
   "openai>=1.30.0",
   "openpyxl>=3.1.2",
+  "Pillow>=10.4.0",
   "pypdf>=4.2.0",
   "python-docx>=1.1.0",
 ]

--- a/src/digester/core/orchestrator.py
+++ b/src/digester/core/orchestrator.py
@@ -34,7 +34,7 @@ def _no_extractable_content_error(documents: List[SourceDocument]) -> str:
         if warnings:
             details.append("Warnings: {warnings}".format(warnings="; ".join(warnings)))
         details.append(
-            "For image-only DOCX files, configure a vision analyzer such as --image-analyzer-kind ollama."
+            "For image-only files with embedded images, configure a vision analyzer such as --image-analyzer-kind ollama."
         )
         return " ".join(details)
     return "No extractable text was found in the supplied inputs."

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -61,7 +61,7 @@ def build_parser() -> argparse.ArgumentParser:
     digest_parser.add_argument(
         "--image-analyzer-kind",
         choices=["openai", "openai-compatible", "ollama", "mock-image"],
-        help="Optional analyzer for embedded DOCX images.",
+        help="Optional analyzer for embedded images in supported source formats.",
     )
     digest_parser.add_argument(
         "--image-analyzer-model",

--- a/src/digester/sources/docx.py
+++ b/src/digester/sources/docx.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from pathlib import Path, PurePosixPath
-import shutil
-import subprocess
-import tempfile
 from typing import List, Optional, Tuple
 
 from docx import Document
@@ -14,29 +10,15 @@ from docx.oxml.text.paragraph import CT_P
 from docx.table import Table
 from docx.text.paragraph import Paragraph
 
-from ..core.models import DocumentSection, EmbeddedImage, ImageAnalysis, SourceDocument, SourceRef
+from ..core.models import DocumentSection, EmbeddedImage, SourceDocument, SourceRef
 from ..images.base import ImageAnalyzer
 from .base import SourceAdapter
+from .embedded_images import analyze_embedded_images, mime_type_for_filename
 
 _BLIP_TAG = ".//{http://schemas.openxmlformats.org/drawingml/2006/main}blip"
 _VML_IMAGE_TAG = ".//{urn:schemas-microsoft-com:vml}imagedata"
 _EMBED_ATTR = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed"
 _RELATIONSHIP_ID_ATTR = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"
-_MIME_TYPES_BY_SUFFIX = {
-    ".emf": "image/x-emf",
-    ".gif": "image/gif",
-    ".jpeg": "image/jpeg",
-    ".jpg": "image/jpeg",
-    ".png": "image/png",
-    ".tif": "image/tiff",
-    ".tiff": "image/tiff",
-    ".webp": "image/webp",
-    ".wmf": "image/x-wmf",
-}
-_VECTOR_IMAGE_SUFFIXES = {".emf", ".wmf"}
-_VECTOR_IMAGE_MIME_TYPES = {"image/emf", "image/x-emf", "image/wmf", "image/x-wmf"}
-
-
 def _nearest_non_empty_paragraph_text(
     paragraphs: List[Paragraph],
     start_index: int,
@@ -61,12 +43,6 @@ def _dedupe_non_empty(items: List[str]) -> List[str]:
         seen.add(normalized)
         result.append(normalized)
     return result
-
-
-def _mime_type_for_filename(filename: str) -> str:
-    return _MIME_TYPES_BY_SUFFIX.get(PurePosixPath(filename).suffix.lower(), "application/octet-stream")
-
-
 def _paragraphs_from_table(table: Table) -> List[Paragraph]:
     paragraphs: List[Paragraph] = []
     seen_cells = set()
@@ -161,7 +137,7 @@ def _extract_embedded_images(
                         ),
                         filename=filename or "image-{index}".format(index=image_index),
                         mime_type=getattr(image_part, "content_type", "")
-                        or _mime_type_for_filename(filename),
+                        or mime_type_for_filename(filename),
                         data=image_part.blob,
                         caption=caption,
                         context_text=nearby_context,
@@ -169,148 +145,6 @@ def _extract_embedded_images(
                 )
                 image_index += 1
     return images
-
-
-def _render_image_analysis(image: EmbeddedImage, analysis: ImageAnalysis) -> str:
-    lines = [
-        "This section summarizes an embedded image from the source document.",
-        "",
-        "Visual summary: {summary}".format(summary=analysis.summary.strip()),
-    ]
-    if image.filename.strip():
-        lines.extend(
-            [
-                "",
-                "Image file: {filename}".format(filename=image.filename.strip()),
-            ]
-        )
-    if image.caption.strip():
-        lines.extend(
-            [
-                "",
-                "Inline caption or nearby text: {caption}".format(caption=image.caption.strip()),
-            ]
-        )
-    if image.context_text.strip():
-        lines.extend(
-            [
-                "",
-                "Nearby document context:",
-                image.context_text.strip(),
-            ]
-        )
-    if analysis.key_points:
-        lines.extend(["", "Key visual details:"])
-        lines.extend("- {point}".format(point=point) for point in analysis.key_points)
-    return "\n".join(lines)
-
-
-def _image_metadata_line(image: EmbeddedImage) -> str:
-    return (
-        "{locator}: file={filename}, mime={mime_type}, bytes={byte_count}"
-    ).format(
-        locator=image.source_ref.locator,
-        filename=image.filename or "(unnamed)",
-        mime_type=image.mime_type or "application/octet-stream",
-        byte_count=len(image.data),
-    )
-
-
-def _image_requires_png_normalization(image: EmbeddedImage) -> bool:
-    suffix = PurePosixPath(image.filename).suffix.lower()
-    return suffix in _VECTOR_IMAGE_SUFFIXES or image.mime_type.lower() in _VECTOR_IMAGE_MIME_TYPES
-
-
-def _image_converter_command(input_path: Path, output_path: Path) -> Optional[List[str]]:
-    inkscape = shutil.which("inkscape")
-    if inkscape:
-        try:
-            help_result = subprocess.run(
-                [inkscape, "--help"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            help_text = "{stdout}\n{stderr}".format(
-                stdout=help_result.stdout,
-                stderr=help_result.stderr,
-            )
-        except Exception:
-            help_text = ""
-        if "--export-png" in help_text:
-            return [inkscape, "--without-gui", str(input_path), "--export-png={output_path}".format(
-                output_path=output_path,
-            )]
-        return [
-            inkscape,
-            str(input_path),
-            "--export-type=png",
-            "--export-filename={output_path}".format(output_path=output_path),
-        ]
-    magick = shutil.which("magick")
-    if magick:
-        return [magick, str(input_path), str(output_path)]
-    convert = shutil.which("convert")
-    if convert:
-        return [convert, str(input_path), str(output_path)]
-    return None
-
-
-def _normalize_image_for_analysis(image: EmbeddedImage) -> Tuple[Optional[EmbeddedImage], str]:
-    if not _image_requires_png_normalization(image):
-        return image, ""
-    suffix = PurePosixPath(image.filename).suffix.lower() or ".img"
-    try:
-        with tempfile.TemporaryDirectory(prefix="bookworm-image-") as directory:
-            input_path = Path(directory) / "input{suffix}".format(suffix=suffix)
-            output_path = Path(directory) / "output.png"
-            input_path.write_bytes(image.data)
-            command = _image_converter_command(input_path=input_path, output_path=output_path)
-            if command is None:
-                return (
-                    None,
-                    (
-                        "Image {details} uses a vector preview format that most vision APIs cannot decode, "
-                        "and no Inkscape or ImageMagick converter was found."
-                    ).format(details=_image_metadata_line(image)),
-                )
-            result = subprocess.run(
-                command,
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if result.returncode != 0:
-                detail = (result.stderr or result.stdout or "converter exited with a non-zero status").strip()
-                return (
-                    None,
-                    "Unable to convert {details} to PNG: {detail}".format(
-                        details=_image_metadata_line(image),
-                        detail=detail,
-                    ),
-                )
-            converted_data = output_path.read_bytes()
-    except Exception as error:
-        return (
-            None,
-            "Unable to convert {details} to PNG: {error}".format(
-                details=_image_metadata_line(image),
-                error=error,
-            ),
-        )
-    converted_filename = "{stem}.png".format(stem=PurePosixPath(image.filename).stem or "image")
-    converted_image = replace(
-        image,
-        filename=converted_filename,
-        mime_type="image/png",
-        data=converted_data,
-    )
-    return converted_image, "Normalized embedded image for analysis: {original} -> {converted}.".format(
-        original=_image_metadata_line(image),
-        converted=_image_metadata_line(converted_image),
-    )
-
-
 class DocxAdapter(SourceAdapter):
     supported_suffixes = (".docx",)
     media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -337,59 +171,11 @@ class DocxAdapter(SourceAdapter):
                 )
             )
         embedded_images = _extract_embedded_images(document=document, source_id=source_id, path=path)
-        notes: List[str] = []
-        warnings: List[str] = []
-        if embedded_images:
-            notes.append(
-                "Detected {count} embedded image(s): {details}.".format(
-                    count=len(embedded_images),
-                    details="; ".join(_image_metadata_line(image) for image in embedded_images),
-                )
-            )
-        if embedded_images and image_analyzer is None:
-            warnings.append(
-                "Detected {count} embedded image(s) but no image analyzer is configured; image content was skipped."
-                .format(count=len(embedded_images))
-            )
-        if image_analyzer is not None:
-            for index, image in enumerate(embedded_images, start=1):
-                analysis_image, normalization_message = _normalize_image_for_analysis(image)
-                if normalization_message and analysis_image is not None:
-                    notes.append(normalization_message)
-                if normalization_message and analysis_image is None:
-                    warnings.append(
-                        "Skipped embedded image {index}: {message}".format(
-                            index=index,
-                            message=normalization_message,
-                        )
-                    )
-                    continue
-                notes.append(
-                    "Analyzing embedded image {index}: {details}.".format(
-                        index=index,
-                        details=_image_metadata_line(analysis_image),
-                    )
-                )
-                try:
-                    analysis = image_analyzer.analyze(analysis_image)
-                    sections.append(
-                        DocumentSection(
-                            heading="Embedded image {index}".format(index=index),
-                            content=_render_image_analysis(analysis_image, analysis),
-                            source_ref=analysis_image.source_ref,
-                            content_kind="image-analysis",
-                        )
-                    )
-                    notes.append(
-                        "Analyzed embedded image {index} successfully.".format(index=index)
-                    )
-                except Exception as error:
-                    warnings.append(
-                        "Failed to analyze embedded image {index}: {error}".format(
-                            index=index,
-                            error=error,
-                        )
-                    )
+        notes, warnings = analyze_embedded_images(
+            sections=sections,
+            embedded_images=embedded_images,
+            image_analyzer=image_analyzer,
+        )
         return SourceDocument(
             source_id=source_id,
             path=path,

--- a/src/digester/sources/embedded_images.py
+++ b/src/digester/sources/embedded_images.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import tempfile
+from typing import List, Optional, Tuple
+
+from ..core.models import DocumentSection, EmbeddedImage, ImageAnalysis
+from ..images.base import ImageAnalyzer
+
+_MIME_TYPES_BY_SUFFIX = {
+    ".emf": "image/x-emf",
+    ".gif": "image/gif",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".png": "image/png",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+    ".webp": "image/webp",
+    ".wmf": "image/x-wmf",
+}
+_VECTOR_IMAGE_SUFFIXES = {".emf", ".wmf"}
+_VECTOR_IMAGE_MIME_TYPES = {"image/emf", "image/x-emf", "image/wmf", "image/x-wmf"}
+
+
+def mime_type_for_filename(filename: str) -> str:
+    return _MIME_TYPES_BY_SUFFIX.get(PurePosixPath(filename).suffix.lower(), "application/octet-stream")
+
+
+def render_image_analysis(image: EmbeddedImage, analysis: ImageAnalysis) -> str:
+    lines = [
+        "This section summarizes an embedded image from the source document.",
+        "",
+        "Visual summary: {summary}".format(summary=analysis.summary.strip()),
+    ]
+    if image.filename.strip():
+        lines.extend(
+            [
+                "",
+                "Image file: {filename}".format(filename=image.filename.strip()),
+            ]
+        )
+    if image.caption.strip():
+        lines.extend(
+            [
+                "",
+                "Inline caption or nearby text: {caption}".format(caption=image.caption.strip()),
+            ]
+        )
+    if image.context_text.strip():
+        lines.extend(
+            [
+                "",
+                "Nearby document context:",
+                image.context_text.strip(),
+            ]
+        )
+    if analysis.key_points:
+        lines.extend(["", "Key visual details:"])
+        lines.extend("- {point}".format(point=point) for point in analysis.key_points)
+    return "\n".join(lines)
+
+
+def image_metadata_line(image: EmbeddedImage) -> str:
+    return (
+        "{locator}: file={filename}, mime={mime_type}, bytes={byte_count}"
+    ).format(
+        locator=image.source_ref.locator,
+        filename=image.filename or "(unnamed)",
+        mime_type=image.mime_type or "application/octet-stream",
+        byte_count=len(image.data),
+    )
+
+
+def _image_requires_png_normalization(image: EmbeddedImage) -> bool:
+    suffix = PurePosixPath(image.filename).suffix.lower()
+    return suffix in _VECTOR_IMAGE_SUFFIXES or image.mime_type.lower() in _VECTOR_IMAGE_MIME_TYPES
+
+
+def _image_converter_command(input_path: Path, output_path: Path) -> Optional[List[str]]:
+    inkscape = shutil.which("inkscape")
+    if inkscape:
+        try:
+            help_result = subprocess.run(
+                [inkscape, "--help"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            help_text = "{stdout}\n{stderr}".format(
+                stdout=help_result.stdout,
+                stderr=help_result.stderr,
+            )
+        except Exception:
+            help_text = ""
+        if "--export-png" in help_text:
+            return [inkscape, "--without-gui", str(input_path), "--export-png={output_path}".format(
+                output_path=output_path,
+            )]
+        return [
+            inkscape,
+            str(input_path),
+            "--export-type=png",
+            "--export-filename={output_path}".format(output_path=output_path),
+        ]
+    magick = shutil.which("magick")
+    if magick:
+        return [magick, str(input_path), str(output_path)]
+    convert = shutil.which("convert")
+    if convert:
+        return [convert, str(input_path), str(output_path)]
+    return None
+
+
+def normalize_image_for_analysis(image: EmbeddedImage) -> Tuple[Optional[EmbeddedImage], str]:
+    if not _image_requires_png_normalization(image):
+        return image, ""
+    suffix = PurePosixPath(image.filename).suffix.lower() or ".img"
+    try:
+        with tempfile.TemporaryDirectory(prefix="bookworm-image-") as directory:
+            input_path = Path(directory) / "input{suffix}".format(suffix=suffix)
+            output_path = Path(directory) / "output.png"
+            input_path.write_bytes(image.data)
+            command = _image_converter_command(input_path=input_path, output_path=output_path)
+            if command is None:
+                return (
+                    None,
+                    (
+                        "Image {details} uses a vector preview format that most vision APIs cannot decode, "
+                        "and no Inkscape or ImageMagick converter was found."
+                    ).format(details=image_metadata_line(image)),
+                )
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "converter exited with a non-zero status").strip()
+                return (
+                    None,
+                    "Unable to convert {details} to PNG: {detail}".format(
+                        details=image_metadata_line(image),
+                        detail=detail,
+                    ),
+                )
+            converted_data = output_path.read_bytes()
+    except Exception as error:
+        return (
+            None,
+            "Unable to convert {details} to PNG: {error}".format(
+                details=image_metadata_line(image),
+                error=error,
+            ),
+        )
+    converted_filename = "{stem}.png".format(stem=PurePosixPath(image.filename).stem or "image")
+    converted_image = replace(
+        image,
+        filename=converted_filename,
+        mime_type="image/png",
+        data=converted_data,
+    )
+    return converted_image, "Normalized embedded image for analysis: {original} -> {converted}.".format(
+        original=image_metadata_line(image),
+        converted=image_metadata_line(converted_image),
+    )
+
+
+def analyze_embedded_images(
+    sections: List[DocumentSection],
+    embedded_images: List[EmbeddedImage],
+    image_analyzer: Optional[ImageAnalyzer],
+) -> Tuple[List[str], List[str]]:
+    notes: List[str] = []
+    warnings: List[str] = []
+    if embedded_images:
+        notes.append(
+            "Detected {count} embedded image(s): {details}.".format(
+                count=len(embedded_images),
+                details="; ".join(image_metadata_line(image) for image in embedded_images),
+            )
+        )
+    if embedded_images and image_analyzer is None:
+        warnings.append(
+            "Detected {count} embedded image(s) but no image analyzer is configured; image content was skipped."
+            .format(count=len(embedded_images))
+        )
+    if image_analyzer is not None:
+        for index, image in enumerate(embedded_images, start=1):
+            analysis_image, normalization_message = normalize_image_for_analysis(image)
+            if normalization_message and analysis_image is not None:
+                notes.append(normalization_message)
+            if normalization_message and analysis_image is None:
+                warnings.append(
+                    "Skipped embedded image {index}: {message}".format(
+                        index=index,
+                        message=normalization_message,
+                    )
+                )
+                continue
+            notes.append(
+                "Analyzing embedded image {index}: {details}.".format(
+                    index=index,
+                    details=image_metadata_line(analysis_image),
+                )
+            )
+            try:
+                analysis = image_analyzer.analyze(analysis_image)
+                sections.append(
+                    DocumentSection(
+                        heading="Embedded image {index}".format(index=index),
+                        content=render_image_analysis(analysis_image, analysis),
+                        source_ref=analysis_image.source_ref,
+                        content_kind="image-analysis",
+                    )
+                )
+                notes.append("Analyzed embedded image {index} successfully.".format(index=index))
+            except Exception as error:
+                warnings.append(
+                    "Failed to analyze embedded image {index}: {error}".format(
+                        index=index,
+                        error=error,
+                    )
+                )
+    return notes, warnings

--- a/src/digester/sources/pdf.py
+++ b/src/digester/sources/pdf.py
@@ -1,13 +1,53 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Optional
+from pathlib import Path, PurePosixPath
+from typing import List, Optional
 
 from pypdf import PdfReader
 
-from ..core.models import DocumentSection, SourceDocument, SourceRef
+from ..core.models import DocumentSection, EmbeddedImage, SourceDocument, SourceRef
 from ..images.base import ImageAnalyzer
 from .base import SourceAdapter
+from .embedded_images import analyze_embedded_images, mime_type_for_filename
+
+
+def _extract_page_images(
+    page,
+    page_number: int,
+    source_id: str,
+    path: Path,
+    image_offset: int,
+    page_text: str,
+) -> List[EmbeddedImage]:
+    embedded_images: List[EmbeddedImage] = []
+    for image in page.images:
+        raw_name = str(getattr(image, "name", "")).strip()
+        filename = PurePosixPath(raw_name).name if raw_name else "page-{page}-image-{index}".format(
+            page=page_number,
+            index=image_offset,
+        )
+        embedded_images.append(
+            EmbeddedImage(
+                image_id="{source_id}-image-{index}".format(
+                    source_id=source_id,
+                    index=image_offset,
+                ),
+                source_ref=SourceRef(
+                    source_id=source_id,
+                    source_path=str(path),
+                    locator="embedded image {index} on page {page}".format(
+                        index=image_offset,
+                        page=page_number,
+                    ),
+                ),
+                filename=filename,
+                mime_type=mime_type_for_filename(filename),
+                data=image.data,
+                context_text=page_text,
+            )
+        )
+        image_offset += 1
+    return embedded_images
 
 
 class PdfAdapter(SourceAdapter):
@@ -23,27 +63,47 @@ class PdfAdapter(SourceAdapter):
         source_id = path.stem.replace(" ", "-").lower()
         sections = []
         warnings = []
+        embedded_images: List[EmbeddedImage] = []
+        image_offset = 1
         for index, page in enumerate(reader.pages, start=1):
             text = (page.extract_text() or "").strip()
-            if not text:
-                warnings.append("Page {page} did not yield extractable text.".format(page=index))
-                continue
-            sections.append(
-                DocumentSection(
-                    heading="Page {page}".format(page=index),
-                    content=text,
-                    source_ref=SourceRef(
-                        source_id=source_id,
-                        source_path=str(path),
-                        locator="page {page}".format(page=index),
-                    ),
+            if text:
+                sections.append(
+                    DocumentSection(
+                        heading="Page {page}".format(page=index),
+                        content=text,
+                        source_ref=SourceRef(
+                            source_id=source_id,
+                            source_path=str(path),
+                            locator="page {page}".format(page=index),
+                        ),
+                    )
                 )
+            else:
+                warnings.append("Page {page} did not yield extractable text.".format(page=index))
+            page_images = _extract_page_images(
+                page=page,
+                page_number=index,
+                source_id=source_id,
+                path=path,
+                image_offset=image_offset,
+                page_text=text,
             )
+            embedded_images.extend(page_images)
+            image_offset += len(page_images)
+        notes, image_warnings = analyze_embedded_images(
+            sections=sections,
+            embedded_images=embedded_images,
+            image_analyzer=image_analyzer,
+        )
+        warnings.extend(image_warnings)
         return SourceDocument(
             source_id=source_id,
             path=path,
             media_type=self.media_type,
             title=path.stem,
             sections=sections,
+            embedded_images=embedded_images,
+            extraction_notes=notes,
             extraction_warnings=warnings,
         )

--- a/src/digester/sources/spreadsheet.py
+++ b/src/digester/sources/spreadsheet.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from bisect import bisect_left, bisect_right
 from pathlib import Path, PurePosixPath
-from typing import List, Optional
+from typing import Dict, List, Optional, Sequence
 
 from openpyxl import load_workbook
 from openpyxl.utils import get_column_letter
@@ -16,13 +17,20 @@ def _render_row(row: List[object]) -> str:
     return " | ".join("" if cell is None else str(cell) for cell in row).strip()
 
 
-def _nearest_non_empty_row_text(rows_by_index, start_index: int, step: int, max_row: int) -> str:
-    index = start_index + step
-    while 1 <= index <= max_row:
-        text = rows_by_index.get(index, "").strip()
-        if text:
-            return text
-        index += step
+def _nearest_non_empty_row_text(
+    rows_by_index: Dict[int, str],
+    non_empty_rows: Sequence[int],
+    start_index: int,
+    step: int,
+) -> str:
+    if step > 0:
+        position = bisect_right(non_empty_rows, start_index)
+        if position < len(non_empty_rows):
+            return rows_by_index[non_empty_rows[position]]
+        return ""
+    position = bisect_left(non_empty_rows, start_index) - 1
+    if position >= 0:
+        return rows_by_index[non_empty_rows[position]]
     return ""
 
 
@@ -38,26 +46,23 @@ def _dedupe_non_empty(items: List[str]) -> List[str]:
     return result
 
 
+def _image_position(image) -> tuple:
+    marker = getattr(getattr(image, "anchor", None), "_from", None)
+    if marker is None:
+        return (0, 0)
+    return (marker.row, marker.col)
+
+
 def _embedded_images_for_sheet(
     sheet,
     source_id: str,
     path: Path,
-    rows_by_index,
-    max_row: int,
+    rows_by_index: Dict[int, str],
+    non_empty_rows: Sequence[int],
     image_offset: int,
 ) -> List[EmbeddedImage]:
     embedded_images: List[EmbeddedImage] = []
-    images = sorted(
-        getattr(sheet, "_images", []),
-        key=lambda image: (
-            getattr(getattr(image, "anchor", None), "_from", None).row
-            if getattr(getattr(image, "anchor", None), "_from", None) is not None
-            else 0,
-            getattr(getattr(image, "anchor", None), "_from", None).col
-            if getattr(getattr(image, "anchor", None), "_from", None) is not None
-            else 0,
-        ),
-    )
+    images = sorted(getattr(sheet, "_images", []), key=_image_position)
     for image in images:
         marker = getattr(getattr(image, "anchor", None), "_from", None)
         row_number = (marker.row + 1) if marker is not None else 1
@@ -78,8 +83,8 @@ def _embedded_images_for_sheet(
         context_text = "\n".join(
             _dedupe_non_empty(
                 [
-                    _nearest_non_empty_row_text(rows_by_index, row_number, -1, max_row),
-                    _nearest_non_empty_row_text(rows_by_index, row_number, 1, max_row),
+                    _nearest_non_empty_row_text(rows_by_index, non_empty_rows, row_number, -1),
+                    _nearest_non_empty_row_text(rows_by_index, non_empty_rows, row_number, 1),
                 ]
             )
         )
@@ -125,12 +130,13 @@ class SpreadsheetAdapter(SourceAdapter):
         image_offset = 1
         for sheet in workbook.worksheets:
             rows = []
-            rows_by_index = {}
+            rows_by_index: Dict[int, str] = {}
             for row_index, row in enumerate(sheet.iter_rows(values_only=True), start=1):
                 rendered = _render_row(list(row))
                 if rendered:
                     rows.append(rendered)
                     rows_by_index[row_index] = rendered
+            non_empty_rows = sorted(rows_by_index)
             sections.append(
                 DocumentSection(
                     heading=sheet.title,
@@ -147,7 +153,7 @@ class SpreadsheetAdapter(SourceAdapter):
                 source_id=source_id,
                 path=path,
                 rows_by_index=rows_by_index,
-                max_row=sheet.max_row,
+                non_empty_rows=non_empty_rows,
                 image_offset=image_offset,
             )
             embedded_images.extend(sheet_images)

--- a/src/digester/sources/spreadsheet.py
+++ b/src/digester/sources/spreadsheet.py
@@ -1,17 +1,112 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import List, Optional
 
 from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
 
-from ..core.models import DocumentSection, SourceDocument, SourceRef
+from ..core.models import DocumentSection, EmbeddedImage, SourceDocument, SourceRef
 from ..images.base import ImageAnalyzer
 from .base import SourceAdapter
+from .embedded_images import analyze_embedded_images, mime_type_for_filename
 
 
 def _render_row(row: List[object]) -> str:
     return " | ".join("" if cell is None else str(cell) for cell in row).strip()
+
+
+def _nearest_non_empty_row_text(rows_by_index, start_index: int, step: int, max_row: int) -> str:
+    index = start_index + step
+    while 1 <= index <= max_row:
+        text = rows_by_index.get(index, "").strip()
+        if text:
+            return text
+        index += step
+    return ""
+
+
+def _dedupe_non_empty(items: List[str]) -> List[str]:
+    seen = set()
+    result: List[str] = []
+    for item in items:
+        normalized = item.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _embedded_images_for_sheet(
+    sheet,
+    source_id: str,
+    path: Path,
+    rows_by_index,
+    max_row: int,
+    image_offset: int,
+) -> List[EmbeddedImage]:
+    embedded_images: List[EmbeddedImage] = []
+    images = sorted(
+        getattr(sheet, "_images", []),
+        key=lambda image: (
+            getattr(getattr(image, "anchor", None), "_from", None).row
+            if getattr(getattr(image, "anchor", None), "_from", None) is not None
+            else 0,
+            getattr(getattr(image, "anchor", None), "_from", None).col
+            if getattr(getattr(image, "anchor", None), "_from", None) is not None
+            else 0,
+        ),
+    )
+    for image in images:
+        marker = getattr(getattr(image, "anchor", None), "_from", None)
+        row_number = (marker.row + 1) if marker is not None else 1
+        column_number = (marker.col + 1) if marker is not None else 1
+        cell_ref = "{column}{row}".format(
+            column=get_column_letter(column_number),
+            row=row_number,
+        )
+        raw_path = str(getattr(image, "path", "")).strip()
+        filename = PurePosixPath(raw_path).name
+        if not filename:
+            image_format = str(getattr(image, "format", "")).strip().lower() or "img"
+            filename = "sheet-image-{index}.{extension}".format(
+                index=image_offset,
+                extension=image_format,
+            )
+        caption = rows_by_index.get(row_number, "")
+        context_text = "\n".join(
+            _dedupe_non_empty(
+                [
+                    _nearest_non_empty_row_text(rows_by_index, row_number, -1, max_row),
+                    _nearest_non_empty_row_text(rows_by_index, row_number, 1, max_row),
+                ]
+            )
+        )
+        embedded_images.append(
+            EmbeddedImage(
+                image_id="{source_id}-image-{index}".format(
+                    source_id=source_id,
+                    index=image_offset,
+                ),
+                source_ref=SourceRef(
+                    source_id=source_id,
+                    source_path=str(path),
+                    locator="embedded image {index} on sheet {sheet} near {cell}".format(
+                        index=image_offset,
+                        sheet=sheet.title,
+                        cell=cell_ref,
+                    ),
+                ),
+                filename=filename,
+                mime_type=mime_type_for_filename(filename),
+                data=image._data(),
+                caption=caption,
+                context_text=context_text,
+            )
+        )
+        image_offset += 1
+    return embedded_images
 
 
 class SpreadsheetAdapter(SourceAdapter):
@@ -23,15 +118,19 @@ class SpreadsheetAdapter(SourceAdapter):
         path: Path,
         image_analyzer: Optional[ImageAnalyzer] = None,
     ) -> SourceDocument:
-        workbook = load_workbook(filename=str(path), data_only=True, read_only=True)
+        workbook = load_workbook(filename=str(path), data_only=True)
         source_id = path.stem.replace(" ", "-").lower()
         sections = []
+        embedded_images: List[EmbeddedImage] = []
+        image_offset = 1
         for sheet in workbook.worksheets:
             rows = []
-            for row in sheet.iter_rows(values_only=True):
+            rows_by_index = {}
+            for row_index, row in enumerate(sheet.iter_rows(values_only=True), start=1):
                 rendered = _render_row(list(row))
                 if rendered:
                     rows.append(rendered)
+                    rows_by_index[row_index] = rendered
             sections.append(
                 DocumentSection(
                     heading=sheet.title,
@@ -43,10 +142,28 @@ class SpreadsheetAdapter(SourceAdapter):
                     ),
                 )
             )
+            sheet_images = _embedded_images_for_sheet(
+                sheet=sheet,
+                source_id=source_id,
+                path=path,
+                rows_by_index=rows_by_index,
+                max_row=sheet.max_row,
+                image_offset=image_offset,
+            )
+            embedded_images.extend(sheet_images)
+            image_offset += len(sheet_images)
+        notes, warnings = analyze_embedded_images(
+            sections=sections,
+            embedded_images=embedded_images,
+            image_analyzer=image_analyzer,
+        )
         return SourceDocument(
             source_id=source_id,
             path=path,
             media_type=self.media_type,
             title=path.stem,
             sections=sections,
+            embedded_images=embedded_images,
+            extraction_notes=notes,
+            extraction_warnings=warnings,
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,9 @@ from typing import List
 
 import pytest
 from docx import Document
+from openpyxl import Workbook
+from openpyxl.drawing.image import Image as SpreadsheetImage
+from PIL import Image as PilImage
 
 from digester.core import DigestConfig
 from digester.core.models import DigestBatchRequest, DigestDecision, TopicDigest
@@ -86,6 +89,25 @@ def _write_docx_with_only_embedded_image(path: Path) -> None:
     document = Document()
     document.add_picture(str(image_path))
     document.save(path)
+
+
+def _write_pdf_with_embedded_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    with PilImage.open(image_path) as image:
+        image.convert("RGB").save(path, "PDF")
+
+
+def _write_spreadsheet_with_embedded_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Summary"
+    sheet.append(["Step", "Details"])
+    sheet.append(["confirm", "Check the dialog"])
+    sheet.add_image(SpreadsheetImage(str(image_path)), "B2")
+    workbook.save(path)
 
 
 def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
@@ -520,13 +542,13 @@ class ImageEchoProvider(LLMProvider):
         return DigestDecision(
             topic_updates=[
                 TopicDigest(
-                    slug="embedded-docx-images",
-                    title="Embedded DOCX Images",
+                    slug="embedded-source-images",
+                    title="Embedded Source Images",
                     routing_description=(
-                        "Use this skill when the source DOCX includes embedded images that affect the workflow."
+                        "Use this skill when the source documents include embedded images that affect the workflow."
                     ),
                     summary=(
-                        "Summarizes the DOCX workflow and preserves embedded image evidence for downstream reuse.\n\n"
+                        "Summarizes the source workflow and preserves embedded image evidence for downstream reuse.\n\n"
                         "{image_summary}"
                     ).format(image_summary=image_summary),
                     key_points=[
@@ -555,7 +577,7 @@ def test_document_digester_includes_embedded_image_analysis_in_topic_output(tmp_
         config=DigestConfig(max_chunk_chars=400, batch_size=4, minimum_batches_before_stop=1),
     ).digest_paths([input_path], output_dir)
 
-    skill_path = output_dir / "copilot" / ".github" / "skills" / "embedded-docx-images" / "SKILL.md"
+    skill_path = output_dir / "copilot" / ".github" / "skills" / "embedded-source-images" / "SKILL.md"
     skill_text = skill_path.read_text(encoding="utf-8")
 
     assert any(chunk.content_kind == "image-analysis" for chunk in result.chunks)
@@ -583,6 +605,45 @@ def test_document_digester_processes_image_only_docx_with_analyzer(tmp_path: Pat
     assert any("Visual summary:" in chunk.text for chunk in result.chunks)
 
 
+def test_document_digester_processes_image_only_pdf_with_analyzer(tmp_path: Path) -> None:
+    input_path = tmp_path / "image-only.pdf"
+    _write_pdf_with_embedded_image(input_path)
+    output_dir = tmp_path / "out"
+
+    result = DocumentDigester(
+        provider=ImageEchoProvider(),
+        image_analyzer=MockImageAnalyzer(model="fake-vision"),
+        config=DigestConfig(max_chunk_chars=400, batch_size=2, minimum_batches_before_stop=1),
+    ).digest_paths([input_path], output_dir)
+
+    assert len(result.documents[0].sections) == 1
+    assert result.documents[0].sections[0].content_kind == "image-analysis"
+    assert result.documents[0].sections[0].source_ref.locator == "embedded image 1 on page 1"
+    assert result.chunks
+    assert all(chunk.content_kind == "image-analysis" for chunk in result.chunks)
+    assert any(chunk.source_ref.locator == "embedded image 1 on page 1" for chunk in result.chunks)
+
+
+def test_document_digester_includes_spreadsheet_image_analysis_in_topic_output(tmp_path: Path) -> None:
+    input_path = tmp_path / "guide.xlsx"
+    _write_spreadsheet_with_embedded_image(input_path)
+    output_dir = tmp_path / "out"
+
+    result = DocumentDigester(
+        provider=ImageEchoProvider(),
+        image_analyzer=MockImageAnalyzer(model="fake-vision"),
+        config=DigestConfig(max_chunk_chars=400, batch_size=4, minimum_batches_before_stop=1),
+    ).digest_paths([input_path], output_dir)
+
+    skill_path = output_dir / "copilot" / ".github" / "skills" / "embedded-source-images" / "SKILL.md"
+    skill_text = skill_path.read_text(encoding="utf-8")
+
+    assert any(chunk.content_kind == "image-analysis" for chunk in result.chunks)
+    assert skill_path.exists()
+    assert "embedded image 1 on sheet Summary near B2" in skill_text
+    assert "Check the dialog" in skill_text
+
+
 def test_document_digester_reports_missing_analyzer_for_image_only_docx(tmp_path: Path) -> None:
     input_path = tmp_path / "image-only.docx"
     _write_docx_with_only_embedded_image(input_path)
@@ -596,4 +657,5 @@ def test_document_digester_reports_missing_analyzer_for_image_only_docx(tmp_path
     message = str(error.value)
     assert "No extractable text was found in the supplied inputs." in message
     assert "Detected 1 embedded image(s), but no image-analysis content was available." in message
+    assert "For image-only files with embedded images" in message
     assert "--image-analyzer-kind ollama" in message

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -6,6 +6,8 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 from docx import Document
 from openpyxl import Workbook
+from openpyxl.drawing.image import Image as SpreadsheetImage
+from PIL import Image as PilImage
 
 from digester.images import MockImageAnalyzer
 from digester.images.base import ImageAnalyzer
@@ -111,6 +113,25 @@ def _write_docx_with_vml_vector_image(path: Path) -> None:
                 target.writestr(item, data)
             target.writestr("word/media/image1.emf", source.read("word/media/image1.png"))
     rewritten.replace(path)
+
+
+def _write_pdf_with_embedded_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    with PilImage.open(image_path) as image:
+        image.convert("RGB").save(path, "PDF")
+
+
+def _write_spreadsheet_with_embedded_image(path: Path) -> None:
+    image_path = path.with_suffix(".png")
+    _write_test_png(image_path)
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Summary"
+    sheet.append(["Item", "Value"])
+    sheet.append(["alpha", 3])
+    sheet.add_image(SpreadsheetImage(str(image_path)), "B2")
+    workbook.save(path)
 
 
 class RecordingReporter:
@@ -288,7 +309,7 @@ def test_registry_normalizes_vector_docx_images_before_analysis(monkeypatch, tmp
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(
-        "digester.sources.docx._image_converter_command",
+        "digester.sources.embedded_images._image_converter_command",
         lambda input_path, output_path: [
             "fake-inkscape",
             str(input_path),
@@ -296,7 +317,7 @@ def test_registry_normalizes_vector_docx_images_before_analysis(monkeypatch, tmp
             "--export-filename={output_path}".format(output_path=output_path),
         ],
     )
-    monkeypatch.setattr("digester.sources.docx.subprocess.run", fake_run)
+    monkeypatch.setattr("digester.sources.embedded_images.subprocess.run", fake_run)
 
     documents = SourceRegistry().load_paths([path], image_analyzer=analyzer)
 
@@ -321,8 +342,11 @@ def test_registry_supports_legacy_inkscape_vector_conversion(monkeypatch, tmp_pa
         _write_test_png(output_path)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr("digester.sources.docx.shutil.which", lambda name: "fake-inkscape" if name == "inkscape" else None)
-    monkeypatch.setattr("digester.sources.docx.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "digester.sources.embedded_images.shutil.which",
+        lambda name: "fake-inkscape" if name == "inkscape" else None,
+    )
+    monkeypatch.setattr("digester.sources.embedded_images.subprocess.run", fake_run)
 
     documents = SourceRegistry().load_paths([path], image_analyzer=analyzer)
 
@@ -337,11 +361,11 @@ def test_registry_skips_vector_docx_images_when_normalization_fails(monkeypatch,
     analyzer = CapturingImageAnalyzer()
 
     monkeypatch.setattr(
-        "digester.sources.docx._image_converter_command",
+        "digester.sources.embedded_images._image_converter_command",
         lambda input_path, output_path: ["fake-convert", str(input_path), str(output_path)],
     )
     monkeypatch.setattr(
-        "digester.sources.docx.subprocess.run",
+        "digester.sources.embedded_images.subprocess.run",
         lambda command, capture_output, text, timeout: SimpleNamespace(
             returncode=1,
             stdout="",
@@ -430,3 +454,35 @@ def test_registry_loads_spreadsheet(tmp_path: Path) -> None:
 
     assert "Item | Value" in documents[0].sections[0].content
     assert "alpha | 3" in documents[0].sections[0].content
+
+
+def test_registry_loads_pdf_embedded_images_with_analyzer(tmp_path: Path) -> None:
+    path = tmp_path / "image-only.pdf"
+    _write_pdf_with_embedded_image(path)
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=MockImageAnalyzer(model="fake-vision"))
+
+    assert len(documents[0].sections) == 1
+    assert documents[0].sections[0].content_kind == "image-analysis"
+    assert documents[0].embedded_images[0].source_ref.locator == "embedded image 1 on page 1"
+    assert documents[0].embedded_images[0].mime_type.startswith("image/")
+    assert documents[0].extraction_notes[0].startswith("Detected 1 embedded image(s): embedded image 1 on page 1: ")
+    assert "Analyzed embedded image 1 successfully." in documents[0].extraction_notes
+    assert documents[0].extraction_warnings == ["Page 1 did not yield extractable text."]
+
+
+def test_registry_loads_spreadsheet_embedded_images_with_analyzer(tmp_path: Path) -> None:
+    path = tmp_path / "sheet-with-image.xlsx"
+    _write_spreadsheet_with_embedded_image(path)
+
+    documents = SourceRegistry().load_paths([path], image_analyzer=MockImageAnalyzer(model="fake-vision"))
+
+    assert len(documents[0].sections) == 2
+    assert documents[0].sections[0].heading == "Summary"
+    assert documents[0].sections[1].content_kind == "image-analysis"
+    assert documents[0].embedded_images[0].caption == "alpha | 3"
+    assert documents[0].embedded_images[0].context_text == "Item | Value"
+    assert documents[0].embedded_images[0].source_ref.locator == "embedded image 1 on sheet Summary near B2"
+    assert "alpha | 3" in documents[0].sections[1].content
+    assert "Item | Value" in documents[0].sections[1].content
+    assert documents[0].extraction_warnings == []


### PR DESCRIPTION
## Summary
- route PDF and spreadsheet embedded images through the shared image-analysis pipeline used by DOCX
- add Pillow as a runtime dependency and update CLI/docs to describe supported embedded-image formats
- cover PDF/XLSX source loading and digestion flows with regression tests

## Testing
- PYTHONPATH=src .venv/bin/pytest -q