### PR TITLE
Add recursive directory parsing and UTF-8 text source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Each agent root also includes a short `INSTALL.md` that lists the documented pro
 
 ## Supported inputs
 
-- Plain text and markdown
+- UTF-8 text files, including plain text, markdown, programming source files, configuration files, and extensionless text files
 - PDF
 - DOCX
 - XLSX/XLSM
@@ -77,6 +77,16 @@ bookworm digest docs/*.txt \
   --model gpt-4.1-mini \
   --api-key-file ~/.config/bookworm/openai.key \
   --max-active-topics 16
+```
+
+Use `--recursive` when an input path is a directory and you want Bookworm to scan nested folders instead of just the directory's top-level supported files.
+
+```bash
+bookworm digest path/to/repo \
+  --recursive \
+  --output-dir out \
+  --provider-kind mock-llm \
+  --model fake-model
 ```
 
 ## Ollama example

--- a/src/digester/interfaces/api.py
+++ b/src/digester/interfaces/api.py
@@ -27,7 +27,12 @@ class DocumentDigester:
         self.image_analyzer = image_analyzer
         self.progress_reporter = progress_reporter or NoOpProgressReporter()
 
-    def digest_paths(self, paths: Sequence[Union[str, Path]], output_dir: Union[str, Path]) -> DigestResult:
+    def digest_paths(
+        self,
+        paths: Sequence[Union[str, Path]],
+        output_dir: Union[str, Path],
+        recursive_directories: bool = False,
+    ) -> DigestResult:
         normalized_paths = [Path(path).resolve() for path in paths]
         output_path = Path(output_dir).resolve()
         self.progress_reporter.persist(
@@ -37,6 +42,7 @@ class DocumentDigester:
             normalized_paths,
             progress_reporter=self.progress_reporter,
             image_analyzer=self.image_analyzer,
+            recursive_directories=recursive_directories,
         )
         self.progress_reporter.persist(
             "Writing artifacts to {path}.".format(path=output_path)

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -20,6 +20,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     digest_parser = subparsers.add_parser("digest", help="Digest source files into markdown artifacts.")
     digest_parser.add_argument("inputs", nargs="+", help="Input files or directories to digest.")
+    digest_parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recursively scan nested directories when an input path is a directory.",
+    )
     digest_parser.add_argument("--output-dir", required=True, help="Directory for markdown outputs.")
     digest_parser.add_argument(
         "--provider-kind",
@@ -287,7 +292,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             progress_reporter=reporter,
         )
         started_at = time.perf_counter()
-        result = digester.digest_paths(args.inputs, args.output_dir)
+        result = digester.digest_paths(
+            args.inputs,
+            args.output_dir,
+            recursive_directories=args.recursive,
+        )
         elapsed_seconds = time.perf_counter() - started_at
         chunk_count = len(result.chunks)
         batch_sizes = list(_batch_sizes(chunk_count, args.batch_size))

--- a/src/digester/sources/registry.py
+++ b/src/digester/sources/registry.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, List, Optional
+from zipfile import BadZipFile
+
+from openpyxl.utils.exceptions import InvalidFileException
+from docx.opc.exceptions import PackageNotFoundError
+from pypdf.errors import PdfReadError
 
 from ..core.models import SourceDocument
 from ..images.base import ImageAnalyzer
@@ -11,6 +16,15 @@ from .docx import DocxAdapter
 from .pdf import PdfAdapter
 from .spreadsheet import SpreadsheetAdapter
 from .text import PlainTextAdapter
+
+_RECOVERABLE_LOAD_ERRORS = (
+    OSError,
+    UnicodeDecodeError,
+    BadZipFile,
+    InvalidFileException,
+    PackageNotFoundError,
+    PdfReadError,
+)
 
 
 class SourceRegistry:
@@ -60,6 +74,13 @@ class SourceRegistry:
         progress_reporter.persist("Scanning directory {name}.".format(name=file_label(path)))
         documents: List[SourceDocument] = []
         for child in sorted(path.iterdir()):
+            if child.is_symlink() and child.is_dir():
+                progress_reporter.persist(
+                    "Skipping symbolic link directory {name} to avoid recursive directory cycles.".format(
+                        name=file_label(child)
+                    )
+                )
+                continue
             if child.is_dir():
                 if not recursive_directories:
                     progress_reporter.persist(
@@ -81,14 +102,23 @@ class SourceRegistry:
             if adapter is None:
                 progress_reporter.persist("Skipping unsupported file {name}.".format(name=file_label(child)))
                 continue
-            documents.append(
-                self._load_file(
-                    child,
-                    progress_reporter,
-                    adapter=adapter,
-                    image_analyzer=image_analyzer,
+
+            try:
+                documents.append(
+                    self._load_file(
+                        child,
+                        progress_reporter,
+                        adapter=adapter,
+                        image_analyzer=image_analyzer,
+                    )
                 )
-            )
+            except _RECOVERABLE_LOAD_ERRORS as error:
+                progress_reporter.persist(
+                    "Warning for {name}: Skipped unreadable source file: {error}".format(
+                        name=file_label(child),
+                        error=error,
+                    )
+                )
         return documents
 
     def _load_file(

--- a/src/digester/sources/registry.py
+++ b/src/digester/sources/registry.py
@@ -20,10 +20,10 @@ class SourceRegistry:
     @staticmethod
     def default_adapters() -> List[SourceAdapter]:
         return [
-            PlainTextAdapter(),
             PdfAdapter(),
             DocxAdapter(),
             SpreadsheetAdapter(),
+            PlainTextAdapter(),
         ]
 
     def load_paths(
@@ -31,53 +31,112 @@ class SourceRegistry:
         paths: Iterable[Path],
         progress_reporter: Optional[ProgressReporter] = None,
         image_analyzer: Optional[ImageAnalyzer] = None,
+        recursive_directories: bool = False,
     ) -> List[SourceDocument]:
         reporter = progress_reporter or NoOpProgressReporter()
         documents: List[SourceDocument] = []
         for path in paths:
             if path.is_dir():
-                reporter.persist("Scanning directory {name}.".format(name=file_label(path)))
                 documents.extend(
-                    self.load_paths(
-                        sorted(child for child in path.iterdir()),
+                    self._load_directory(
+                        path,
                         progress_reporter=reporter,
                         image_analyzer=image_analyzer,
+                        recursive_directories=recursive_directories,
                     )
                 )
                 continue
-            adapter = self._resolve_adapter(path)
-            reporter.update(
-                "Loading {name} with {adapter}.".format(
-                    name=file_label(path),
-                    adapter=adapter.__class__.__name__,
-                )
-            )
-            document = adapter.load(path, image_analyzer=image_analyzer)
-            documents.append(document)
-            reporter.persist(
-                "Loaded {name} with {sections} section(s).".format(
-                    name=file_label(path),
-                    sections=len(document.sections),
-                )
-            )
-            for note in document.extraction_notes:
-                reporter.persist(
-                    "Note for {name}: {note}".format(
-                        name=file_label(path),
-                        note=note,
-                    )
-                )
-            for warning in document.extraction_warnings:
-                reporter.persist(
-                    "Warning for {name}: {warning}".format(
-                        name=file_label(path),
-                        warning=warning,
-                    )
-                )
+            documents.append(self._load_file(path, reporter, image_analyzer=image_analyzer))
         return documents
 
-    def _resolve_adapter(self, path: Path) -> SourceAdapter:
+    def _load_directory(
+        self,
+        path: Path,
+        *,
+        progress_reporter: ProgressReporter,
+        image_analyzer: Optional[ImageAnalyzer],
+        recursive_directories: bool,
+    ) -> List[SourceDocument]:
+        progress_reporter.persist("Scanning directory {name}.".format(name=file_label(path)))
+        documents: List[SourceDocument] = []
+        for child in sorted(path.iterdir()):
+            if child.is_dir():
+                if not recursive_directories:
+                    progress_reporter.persist(
+                        "Skipping nested directory {name}; pass --recursive to scan nested directories.".format(
+                            name=file_label(child)
+                        )
+                    )
+                    continue
+                documents.extend(
+                    self._load_directory(
+                        child,
+                        progress_reporter=progress_reporter,
+                        image_analyzer=image_analyzer,
+                        recursive_directories=True,
+                    )
+                )
+                continue
+            adapter = self._resolve_adapter(child)
+            if adapter is None:
+                progress_reporter.persist("Skipping unsupported file {name}.".format(name=file_label(child)))
+                continue
+            documents.append(
+                self._load_file(
+                    child,
+                    progress_reporter,
+                    adapter=adapter,
+                    image_analyzer=image_analyzer,
+                )
+            )
+        return documents
+
+    def _load_file(
+        self,
+        path: Path,
+        progress_reporter: ProgressReporter,
+        *,
+        adapter: Optional[SourceAdapter] = None,
+        image_analyzer: Optional[ImageAnalyzer] = None,
+    ) -> SourceDocument:
+        resolved_adapter = adapter or self._require_adapter(path)
+        progress_reporter.update(
+            "Loading {name} with {adapter}.".format(
+                name=file_label(path),
+                adapter=resolved_adapter.__class__.__name__,
+            )
+        )
+        document = resolved_adapter.load(path, image_analyzer=image_analyzer)
+        progress_reporter.persist(
+            "Loaded {name} with {sections} section(s).".format(
+                name=file_label(path),
+                sections=len(document.sections),
+            )
+        )
+        for note in document.extraction_notes:
+            progress_reporter.persist(
+                "Note for {name}: {note}".format(
+                    name=file_label(path),
+                    note=note,
+                )
+            )
+        for warning in document.extraction_warnings:
+            progress_reporter.persist(
+                "Warning for {name}: {warning}".format(
+                    name=file_label(path),
+                    warning=warning,
+                )
+            )
+        return document
+
+    def _resolve_adapter(self, path: Path) -> Optional[SourceAdapter]:
         for adapter in self.adapters:
             if adapter.supports(path):
                 return adapter
-        raise ValueError("Unsupported source type: {path}".format(path=path))
+        return None
+
+    def _require_adapter(self, path: Path) -> SourceAdapter:
+        adapter = self._resolve_adapter(path)
+        if adapter is None:
+            raise ValueError("Unsupported source type: {path}".format(path=path))
+        return adapter

--- a/src/digester/sources/text.py
+++ b/src/digester/sources/text.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 from pathlib import Path
 from typing import Optional
 
@@ -117,7 +118,8 @@ def _looks_like_utf8_text(path: Path, sample_size: int = 8192) -> bool:
     if b"\x00" in sample:
         return False
     try:
-        sample.decode("utf-8")
+        decoder = codecs.getincrementaldecoder("utf-8")()
+        decoder.decode(sample, final=False)
     except UnicodeDecodeError:
         return False
     return True

--- a/src/digester/sources/text.py
+++ b/src/digester/sources/text.py
@@ -9,8 +9,76 @@ from .base import SourceAdapter
 
 
 class PlainTextAdapter(SourceAdapter):
-    supported_suffixes = (".txt", ".md", ".rst")
+    supported_suffixes = (
+        ".txt",
+        ".md",
+        ".rst",
+        ".py",
+        ".pyi",
+        ".js",
+        ".jsx",
+        ".ts",
+        ".tsx",
+        ".java",
+        ".kt",
+        ".kts",
+        ".go",
+        ".rs",
+        ".c",
+        ".h",
+        ".cc",
+        ".hh",
+        ".cpp",
+        ".hpp",
+        ".cxx",
+        ".hxx",
+        ".cs",
+        ".php",
+        ".rb",
+        ".swift",
+        ".scala",
+        ".sh",
+        ".bash",
+        ".zsh",
+        ".fish",
+        ".ps1",
+        ".sql",
+        ".html",
+        ".css",
+        ".scss",
+        ".sass",
+        ".less",
+        ".xml",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".ini",
+        ".cfg",
+        ".conf",
+    )
     media_type = "text/plain"
+    supported_filenames = (
+        "dockerfile",
+        "makefile",
+        "jenkinsfile",
+        "procfile",
+        "vagrantfile",
+        "gemfile",
+        "rakefile",
+        ".env",
+        ".gitignore",
+        ".gitattributes",
+        ".editorconfig",
+    )
+
+    def supports(self, path: Path) -> bool:
+        if super().supports(path):
+            return True
+        lowered_name = path.name.lower()
+        if lowered_name in self.supported_filenames or lowered_name.startswith(".env."):
+            return True
+        return _looks_like_utf8_text(path)
 
     def load(
         self,
@@ -36,3 +104,20 @@ class PlainTextAdapter(SourceAdapter):
                 )
             ],
         )
+
+
+def _looks_like_utf8_text(path: Path, sample_size: int = 8192) -> bool:
+    try:
+        with path.open("rb") as stream:
+            sample = stream.read(sample_size)
+    except OSError:
+        return False
+    if not sample:
+        return True
+    if b"\x00" in sample:
+        return False
+    try:
+        sample.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,34 @@ def test_cli_digest_command(monkeypatch, tmp_path: Path, capsys) -> None:
     assert "Generated" in captured.err
 
 
+def test_cli_digest_command_passes_recursive_directory_flag(monkeypatch, tmp_path: Path, capsys) -> None:
+    docs_dir = tmp_path / "docs"
+    nested_dir = docs_dir / "guides"
+    nested_dir.mkdir(parents=True)
+    (docs_dir / "overview.txt").write_text("overview", encoding="utf-8")
+    (nested_dir / "setup.py").write_text("print('nested')\n", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    monkeypatch.setattr(cli, "create_provider", lambda settings: CliFakeProvider())
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(docs_dir),
+            "--recursive",
+            "--output-dir",
+            str(output_dir),
+            "--model",
+            "fake-model",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Loaded overview.txt with 1 section(s)." in captured.err
+    assert "Loaded setup.py with 1 section(s)." in captured.err
+
+
 def test_cli_validates_provider_before_digestion(monkeypatch, tmp_path: Path, capsys) -> None:
     input_path = tmp_path / "notes.txt"
     input_path.write_text("A concise document.", encoding="utf-8")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -175,6 +175,31 @@ def test_document_digester_writes_topic_files_and_index(tmp_path: Path) -> None:
     assert any("Generated " in message and "copilot/INSTALL.md" in message for message in persisted)
 
 
+def test_document_digester_recursively_loads_directory_inputs_only_when_requested(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    nested_dir = docs_dir / "guides"
+    nested_dir.mkdir(parents=True)
+    root_path = docs_dir / "overview.txt"
+    nested_path = nested_dir / "setup.py"
+    root_path.write_text("Top-level overview.", encoding="utf-8")
+    nested_path.write_text("print('nested setup')\n", encoding="utf-8")
+
+    non_recursive_result = DocumentDigester(
+        provider=FakeProvider(),
+        config=DigestConfig(max_chunk_chars=200, batch_size=10),
+    ).digest_paths([docs_dir], tmp_path / "out-non-recursive")
+
+    recursive_result = DocumentDigester(
+        provider=FakeProvider(),
+        config=DigestConfig(max_chunk_chars=200, batch_size=10),
+    ).digest_paths([docs_dir], tmp_path / "out-recursive", recursive_directories=True)
+
+    non_recursive_paths = {Path(chunk.source_ref.source_path) for chunk in non_recursive_result.chunks}
+    recursive_paths = {Path(chunk.source_ref.source_path) for chunk in recursive_result.chunks}
+    assert non_recursive_paths == {root_path}
+    assert recursive_paths == {root_path, nested_path}
+
+
 class ManyTopicProvider(LLMProvider):
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
         chunk = request.chunk_batch[0]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -202,6 +202,29 @@ def test_registry_recursively_loads_supported_files_from_directories_when_reques
     assert loaded_paths == {root_path, nested_path}
 
 
+def test_registry_skips_symbolic_link_directories_during_recursive_scan(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    supported_path = docs_dir / "notes.txt"
+    loop_path = docs_dir / "loop"
+    supported_path.write_text("plain text", encoding="utf-8")
+    loop_path.symlink_to(docs_dir, target_is_directory=True)
+    reporter = RecordingReporter()
+
+    documents = SourceRegistry().load_paths(
+        [docs_dir],
+        progress_reporter=reporter,
+        recursive_directories=True,
+    )
+
+    persisted = [message for kind, message in reporter.messages if kind == "persist"]
+    assert [document.path for document in documents] == [supported_path]
+    assert any(
+        message == "Skipping symbolic link directory loop to avoid recursive directory cycles."
+        for message in persisted
+    )
+
+
 def test_registry_skips_unsupported_files_while_scanning_directories(tmp_path: Path) -> None:
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
@@ -213,6 +236,25 @@ def test_registry_skips_unsupported_files_while_scanning_directories(tmp_path: P
     documents = SourceRegistry().load_paths([docs_dir])
 
     assert [document.path for document in documents] == [supported_path]
+
+
+def test_registry_skips_unreadable_supported_files_while_scanning_directories(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    supported_path = docs_dir / "notes.txt"
+    broken_docx_path = docs_dir / "broken.docx"
+    supported_path.write_text("plain text", encoding="utf-8")
+    broken_docx_path.write_text("not a real docx archive", encoding="utf-8")
+    reporter = RecordingReporter()
+
+    documents = SourceRegistry().load_paths([docs_dir], progress_reporter=reporter)
+
+    persisted = [message for kind, message in reporter.messages if kind == "persist"]
+    assert [document.path for document in documents] == [supported_path]
+    assert any(
+        message.startswith("Warning for broken.docx: Skipped unreadable source file:")
+        for message in persisted
+    )
 
 
 def test_registry_supports_utf8_text_files_as_plain_text(tmp_path: Path) -> None:
@@ -232,6 +274,16 @@ def test_registry_supports_utf8_text_files_as_plain_text(tmp_path: Path) -> None
     assert documents[1].sections[0].content == "FROM python:3.12\n"
     assert documents[2].sections[0].content == "DEBUG=true\n"
     assert documents[3].sections[0].content == "steps: [lint, test]\n"
+
+
+def test_registry_accepts_utf8_text_when_sample_ends_mid_character(tmp_path: Path) -> None:
+    path = tmp_path / "BUILD"
+    path.write_bytes((b"a" * 8191) + "é".encode("utf-8") + b"\n")
+
+    documents = SourceRegistry().load_paths([path])
+
+    assert len(documents) == 1
+    assert documents[0].sections[0].content == ("a" * 8191) + "é\n"
 
 
 def test_registry_loads_docx(tmp_path: Path) -> None:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -174,7 +174,7 @@ def test_registry_loads_plain_text(tmp_path: Path) -> None:
     assert documents[0].sections[0].content == "alpha\n\nbeta"
 
 
-def test_registry_recursively_loads_supported_files_from_directories(tmp_path: Path) -> None:
+def test_registry_loads_only_top_level_supported_files_from_directories_by_default(tmp_path: Path) -> None:
     nested_dir = tmp_path / "docs" / "guides"
     nested_dir.mkdir(parents=True)
     root_path = tmp_path / "docs" / "overview.txt"
@@ -185,7 +185,53 @@ def test_registry_recursively_loads_supported_files_from_directories(tmp_path: P
     documents = SourceRegistry().load_paths([tmp_path / "docs"])
 
     loaded_paths = {document.path for document in documents}
+    assert loaded_paths == {root_path}
+
+
+def test_registry_recursively_loads_supported_files_from_directories_when_requested(tmp_path: Path) -> None:
+    nested_dir = tmp_path / "docs" / "guides"
+    nested_dir.mkdir(parents=True)
+    root_path = tmp_path / "docs" / "overview.txt"
+    nested_path = nested_dir / "setup.md"
+    root_path.write_text("root document", encoding="utf-8")
+    nested_path.write_text("nested document", encoding="utf-8")
+
+    documents = SourceRegistry().load_paths([tmp_path / "docs"], recursive_directories=True)
+
+    loaded_paths = {document.path for document in documents}
     assert loaded_paths == {root_path, nested_path}
+
+
+def test_registry_skips_unsupported_files_while_scanning_directories(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    supported_path = docs_dir / "notes.txt"
+    unsupported_path = docs_dir / "diagram.png"
+    supported_path.write_text("plain text", encoding="utf-8")
+    _write_test_png(unsupported_path)
+
+    documents = SourceRegistry().load_paths([docs_dir])
+
+    assert [document.path for document in documents] == [supported_path]
+
+
+def test_registry_supports_utf8_text_files_as_plain_text(tmp_path: Path) -> None:
+    python_path = tmp_path / "main.py"
+    dockerfile_path = tmp_path / "Dockerfile"
+    env_path = tmp_path / ".env.local"
+    extensionless_path = tmp_path / "BUILD"
+    python_path.write_text("print('hello')\n", encoding="utf-8")
+    dockerfile_path.write_text("FROM python:3.12\n", encoding="utf-8")
+    env_path.write_text("DEBUG=true\n", encoding="utf-8")
+    extensionless_path.write_text("steps: [lint, test]\n", encoding="utf-8")
+
+    documents = SourceRegistry().load_paths([python_path, dockerfile_path, env_path, extensionless_path])
+
+    assert [document.path for document in documents] == [python_path, dockerfile_path, env_path, extensionless_path]
+    assert documents[0].sections[0].content == "print('hello')\n"
+    assert documents[1].sections[0].content == "FROM python:3.12\n"
+    assert documents[2].sections[0].content == "DEBUG=true\n"
+    assert documents[3].sections[0].content == "steps: [lint, test]\n"
 
 
 def test_registry_loads_docx(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a `--recursive` flag and thread recursive directory scanning through the CLI, API, and source registry
- scan directories for supported sources while skipping unsupported binary files instead of failing the whole run
- treat UTF-8 text files, including extensionless files, as plain-text sources and document the new behavior

## Testing
- PYTHONPATH=src .venv/bin/pytest -q