### PR TITLE
Refine digester prompt guidance

### DIFF
--- a/src/digester/core/prompts.py
+++ b/src/digester/core/prompts.py
@@ -6,6 +6,35 @@ from typing import Sequence
 from .models import DigestBatchRequest, TopicDigest
 
 
+_TOPIC_OUTPUT_CONTRACT = (
+    "Return strict JSON only. "
+    "Digest responses must include topic_updates, should_continue, rationale. "
+    "Finalize responses must include topics. "
+    "Each topic object must include slug, title, routing_description, summary, key_points, workflow_notes, references. "
+    "references entries must contain source_id, source_path, locator. "
+    "routing_description must be a concrete when-to-use sentence for another agent; if needed, when_to_use may be used as an alias for routing_description. "
+    "summary should usually be 2-5 compact paragraphs when the source supports it. "
+    "key_points should usually contain 5-12 concrete bullet-style items for dense material. "
+    "workflow_notes should usually contain 3-8 source-backed caveats, checks, or operator notes."
+)
+
+
+_TOPIC_QUALITY_GUIDANCE = (
+    "Treat each topic like a section-level skill file that another agent could discover from a SKILL.md description and reuse on its own. "
+    "Write summaries as markdown-ready purpose statements that explain what task the skill helps with and what context it preserves. "
+    "Write key_points as actionable instructions, constraints, workflow steps, commands, or checks, not vague observations. "
+    "workflow_notes must preserve caveats, validation checks, warnings, escalation hints, and source-backed operator guidance. "
+    "Compress repetition, but do not compress away procedures, dependencies, sequencing, concrete implementation detail, commands, configuration values, or failure and recovery notes."
+)
+
+
+_ROUTING_EXAMPLE_GUIDANCE = (
+    'Example routing_description values: bad="Python web framework"; '
+    'good="Use this skill when setting up Flask middleware or debugging request routing." '
+    'Good topic objects contain realistic summaries, concrete key_points, and grounded references instead of placeholder labels.'
+)
+
+
 def _source_ref_payload(topic: TopicDigest):
     return [
         {
@@ -23,17 +52,14 @@ def build_digest_system_prompt() -> str:
         "and decide whether the currently visible topics likely need more adjacent chunks before they are complete. Preserve high-value operational detail for downstream coding agents such as Codex, Claude Code, and Copilot, "
         "especially setup flows, hardware installation steps, wiring order, firmware or software prerequisites, commands, "
         "configuration values, validation checks, warnings, failure conditions, and recovery notes. "
-        "Compress repetition, but do not compress away procedures, dependencies, sequencing, or concrete implementation detail. "
-        "Return strict JSON with keys: topic_updates, should_continue, rationale. "
-        "Each topic update must include slug, title, routing_description, summary, key_points, workflow_notes, references. "
-        "references must contain source_id, source_path, locator. "
-        "Treat each topic like a section-level skill file that another agent could discover from a SKILL.md description and reuse on its own. "
-        "routing_description must explicitly say when another agent should load the skill. "
+        f"{_TOPIC_OUTPUT_CONTRACT} "
+        f"{_TOPIC_QUALITY_GUIDANCE} "
+        f"{_ROUTING_EXAMPLE_GUIDANCE} "
         "Some chunks may be image-analysis content derived from embedded document images; treat those summaries and key points as grounded evidence from the cited image location, not as speculative captions. "
-        "Write summaries as markdown-ready purpose statements that explain what task the skill helps with and what context it preserves. "
-        "Write key_points as actionable instructions, constraints, workflow steps, commands, or checks, not vague observations. "
-        "workflow_notes must preserve caveats, validation checks, warnings, and source-backed operator guidance. "
-        "Set should_continue to false only when the current visible topics already have strong coverage and the next chunks are more likely to introduce different topics than extend these ones."
+        "Use should_continue=true when the visible topic still looks incomplete or likely continues in upcoming chunks. "
+        "Use should_continue=false when the visible topics already have strong coverage and the next chunks are more likely to introduce different topics than extend these ones. "
+        "Heuristics for should_continue=false: prefer false when most current chunks do not overlap with the active topics, or when several visible topics already look finalized and the batch is pivoting into a new area. "
+        "When uncertain, prefer should_continue=true so the next adjacent batch can confirm continuity."
     )
 
 
@@ -67,17 +93,13 @@ def build_digest_user_prompt(request: DigestBatchRequest) -> str:
         "New chunks:\n{chunks}\n\n"
         "Constraints:\n"
         "- Keep at most {max_topics} active topics in view for this batch.\n"
-        "- Topics should behave like section-level skill files for coding agents: each one should cover a coherent, reusable slice of the source rather than the whole corpus.\n"
         "- image-analysis chunks come from embedded visuals; preserve concrete details from them when they add workflow, UI, diagram, or configuration evidence.\n"
-        "- routing_description must say when another agent should load the skill, without copying the title.\n"
-        "- Summaries should be rich, actionable, and markdown-ready, usually 2-5 compact paragraphs when the material supports it.\n"
         "- Preserve setup sequences, hardware steps, prerequisites, commands, parameter values, safety notes, verification steps, and troubleshooting clues when present.\n"
-        "- Key points should be concrete, imperative when useful, and numerous enough to preserve important detail; prefer roughly 5-12 bullets when the source is dense.\n"
-        "- workflow_notes should preserve validation checks, caveats, escalation hints, and source-backed usage notes.\n"
         "- Prefer operational rules, workflow steps, constraints, examples, commands, validation checks, and failure modes over generic observations.\n"
         "- Merge overlapping ideas instead of creating duplicates.\n"
         "- Favor detail that helps another engineer or agent reproduce the setup, understand the implementation, or avoid mistakes.\n"
-        "- Use should_continue=true when the visible topic still looks incomplete or likely continues in upcoming chunks. Use should_continue=false when these visible topics look complete even if later chunks may contain different topics."
+        "- If a candidate topic is still thin, expand it with concrete evidence from this batch instead of returning a placeholder.\n"
+        "- Use should_continue=false when the visible topics look complete and this batch is mostly pivoting into different topics; otherwise prefer true."
     ).format(
         batch=request.batch_number,
         total=request.total_batches,
@@ -90,12 +112,10 @@ def build_digest_user_prompt(request: DigestBatchRequest) -> str:
 def build_finalize_system_prompt() -> str:
     return (
         "You are preparing final topic digests for markdown export as agent-readable skill files. "
-        "Return strict JSON with a single key named topics. "
-        "Each topic must include slug, title, routing_description, summary, key_points, workflow_notes, references. "
+        f"{_TOPIC_OUTPUT_CONTRACT} "
+        f"{_TOPIC_QUALITY_GUIDANCE} "
+        f"{_ROUTING_EXAMPLE_GUIDANCE} "
         "Produce rich markdown-ready summaries that keep the most useful implementation and setup detail. Each topic should read like a reusable skill file for coding agents such as Codex, Claude Code, and Copilot. "
-        "routing_description must be explicit enough to drive frontmatter description and a When To Use section without inferring it from the summary. "
-        "Key points must be actionable instructions, constraints, ordered workflow guidance, examples, commands, or checks. "
-        "workflow_notes must preserve validation checks, warnings, caveats, and source-backed operating guidance. "
         "Do not collapse away hardware setup flows, ordered procedures, commands, prerequisites, warnings, validation checks, or troubleshooting notes. "
         "Remove duplication, but preserve concrete facts and enough detail that another LLM or engineer could act on the output without rereading the whole source."
     )
@@ -118,6 +138,7 @@ def build_finalize_user_prompt(topics: Sequence[TopicDigest]) -> str:
         "Finalize these topics for markdown export. Expand weak summaries into more useful detail where the existing topic data supports it. "
         "Make routing_description strong enough for a frontmatter description and When To Use section. "
         "Make workflow_notes capture validation checks, caveats, and source-backed operating guidance. "
+        "Aim for summaries of 2-5 compact paragraphs when the source supports it, key_points with roughly 5-12 concrete items for dense topics, and workflow_notes with 3-8 grounded notes. "
         "Keep the output concise enough for downstream context windows, but detailed enough to preserve setup flow, operational nuance, and important edge cases.\n"
         "{payload}"
     ).format(payload=json.dumps(payload, indent=2))

--- a/src/digester/images/openai_image_analyzer.py
+++ b/src/digester/images/openai_image_analyzer.py
@@ -16,6 +16,10 @@ def _build_image_system_prompt() -> str:
         "Return strict JSON with keys: summary, key_points. "
         "Describe only details that are visible in the image or grounded by the supplied nearby document context. "
         "Preserve operationally useful information such as UI text, commands, diagrams, labels, configuration values, warnings, or workflow order when present. "
+        "If the image is a diagram or flowchart, describe the named nodes, edges, and sequence. "
+        "If it is a UI screenshot, describe visible controls, labels, status text, and notable layout cues. "
+        "If it is a table or chart, summarize the key values, headings, and visible patterns. "
+        "If it is a photo, describe only the visible objects or states that matter to the surrounding document. "
         "Do not invent unreadable details."
     )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -8,6 +8,7 @@ from digester.core.prompts import (
     build_finalize_system_prompt,
     build_finalize_user_prompt,
 )
+from digester.images.openai_image_analyzer import _build_image_system_prompt
 
 
 def test_digest_prompts_preserve_setup_and_hardware_detail() -> None:
@@ -39,14 +40,17 @@ def test_digest_prompts_preserve_setup_and_hardware_detail() -> None:
     assert "Codex, Claude Code, and Copilot" in system_prompt
     assert "SKILL.md description" in system_prompt
     assert "routing_description" in system_prompt
+    assert "when_to_use may be used as an alias" in system_prompt
     assert "workflow_notes" in system_prompt
+    assert 'bad="Python web framework"' in system_prompt
+    assert 'good="Use this skill when setting up Flask middleware or debugging request routing."' in system_prompt
+    assert "When uncertain, prefer should_continue=true" in system_prompt
     assert "setup sequences" in user_prompt
     assert "verification steps" in user_prompt
-    assert "5-12 bullets" in user_prompt
     assert "active topics in view" in user_prompt
-    assert "routing_description must say when another agent should load the skill" in user_prompt
     assert "operational rules" in user_prompt
-    assert "later chunks may contain different topics" in user_prompt
+    assert "expand it with concrete evidence from this batch" in user_prompt
+    assert "mostly pivoting into different topics" in user_prompt
 
 
 def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
@@ -74,8 +78,11 @@ def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
     assert "hardware setup flows" in system_prompt
     assert "routing_description" in system_prompt
     assert "workflow_notes" in system_prompt
+    assert "when_to_use may be used as an alias" in system_prompt
+    assert 'good="Use this skill when setting up Flask middleware or debugging request routing."' in system_prompt
     assert "Expand weak summaries" in user_prompt
     assert "Make routing_description strong enough" in user_prompt
+    assert "workflow_notes with 3-8 grounded notes" in user_prompt
     assert "setup flow, operational nuance, and important edge cases" in user_prompt
     assert '"source_id": "setup-guide"' in user_prompt
     assert '"source_path": "/tmp/setup-guide.txt"' in user_prompt
@@ -88,3 +95,13 @@ def test_finalize_prompts_request_richer_markdown_ready_output() -> None:
             "locator": "section 2",
         }
     ]
+
+
+def test_image_prompt_requests_type_specific_grounded_detail() -> None:
+    system_prompt = _build_image_system_prompt()
+
+    assert "diagram or flowchart" in system_prompt
+    assert "UI screenshot" in system_prompt
+    assert "table or chart" in system_prompt
+    assert "photo" in system_prompt
+    assert "Do not invent unreadable details." in system_prompt


### PR DESCRIPTION
Summary:
- reduce duplicated prompt guidance by extracting shared topic-contract text
- strengthen digest/finalize prompts with explicit length targets, routing examples, and clearer should_continue heuristics
- expand image-analysis prompt guidance and cover the new wording with prompt tests

Verification:
- /home/gigo/.openclaw/projects/bookworm/.venv/bin/pytest -q tests/test_prompts.py
- /home/gigo/.openclaw/projects/bookworm/.venv/bin/pytest -q tests/test_providers.py
- python -m compileall src
- Full /home/gigo/.openclaw/projects/bookworm/.venv/bin/pytest currently stops during collection because this repo's .venv is missing Pillow (ModuleNotFoundError: PIL)

Notes:
- This intentionally scopes issue #25 to low-risk prompt improvements rather than changing TopicDigest.merge() or provider sampling behavior in the same PR.

Fixes #25