### PR TITLE
Strengthen malformed JSON retries

### DIFF
--- a/src/digester/providers/base.py
+++ b/src/digester/providers/base.py
@@ -8,6 +8,10 @@ from ..core.models import DigestBatchRequest, DigestDecision, TopicDigest
 from ..utils.progress import NoOpProgressReporter, ProgressReporter
 
 
+def _compact_json_example(payload: object) -> str:
+    return json.dumps(payload, separators=(",", ":"))
+
+
 def _readable_preview(text: str, head_chars: int = 160, tail_chars: int = 80) -> str:
     if len(text) <= head_chars + tail_chars:
         return text
@@ -188,6 +192,16 @@ class LLMProvider(ABC):
                     guidance=_json_error_guidance(payload_label, error.pos, len(response_text)),
                 )
             ) from error
+
+    def _build_retry_system_prompt(self, system_prompt: str, example_payload: object) -> str:
+        return (
+            "{prompt} Return only one complete JSON object with no markdown fences, no commentary, "
+            "and no trailing text. Ensure every key, string, bracket, and brace is fully closed. "
+            "Follow this exact JSON shape example: {example}"
+        ).format(
+            prompt=system_prompt,
+            example=_compact_json_example(example_payload),
+        )
 
     def validate_configuration(self) -> None:
         return None

--- a/src/digester/providers/ollama_provider.py
+++ b/src/digester/providers/ollama_provider.py
@@ -109,7 +109,12 @@ class OllamaProvider(LLMProvider):
         self._log_response("Ollama", self.model, content, perf_counter() - started_at)
         return content
 
-    def _complete_json(self, system_prompt: str, user_prompt: str) -> Dict[str, object]:
+    def _complete_json(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        retry_example_payload: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
         content = self._request_content(system_prompt=system_prompt, user_prompt=user_prompt)
         try:
             return self._parse_json_response("Ollama", self.model, content)
@@ -117,12 +122,18 @@ class OllamaProvider(LLMProvider):
             if "invalid JSON in the model response" not in str(error):
                 raise
         self.progress_reporter.verbose(
-            "Verbose: Ollama returned malformed JSON; retrying once with a stricter JSON-only instruction."
+            "Verbose: Ollama returned malformed JSON; retrying once with a stricter JSON-only instruction and a compact schema example."
         )
-        retry_system_prompt = (
-            "{prompt} Return only one complete JSON object with no markdown fences, no commentary, "
-            "and no trailing text. Ensure every key, string, bracket, and brace is fully closed."
-        ).format(prompt=system_prompt)
+        if retry_example_payload is None:
+            retry_system_prompt = (
+                "{prompt} Return only one complete JSON object with no markdown fences, no commentary, "
+                "and no trailing text. Ensure every key, string, bracket, and brace is fully closed."
+            ).format(prompt=system_prompt)
+        else:
+            retry_system_prompt = self._build_retry_system_prompt(
+                system_prompt=system_prompt,
+                example_payload=retry_example_payload,
+            )
         retry_content = self._request_content(system_prompt=retry_system_prompt, user_prompt=user_prompt)
         return self._parse_json_response("Ollama", self.model, retry_content)
 
@@ -130,6 +141,27 @@ class OllamaProvider(LLMProvider):
         payload = self._complete_json(
             system_prompt=build_digest_system_prompt(),
             user_prompt=build_digest_user_prompt(request),
+            retry_example_payload={
+                "topic_updates": [
+                    {
+                        "slug": "example-topic",
+                        "title": "Example Topic",
+                        "routing_description": "Use this skill when reviewing the example workflow.",
+                        "summary": "Summarizes the example workflow and its constraints.",
+                        "key_points": ["Follow the example workflow in order."],
+                        "workflow_notes": ["Validate the example output before reuse."],
+                        "references": [
+                            {
+                                "source_id": "example-source",
+                                "source_path": "/tmp/example-source.txt",
+                                "locator": "section 1",
+                            }
+                        ],
+                    }
+                ],
+                "should_continue": False,
+                "rationale": "Example rationale.",
+            },
         )
         fallback_refs = [chunk.source_ref for chunk in request.chunk_batch]
         return parse_digest_decision(payload, fallback_refs=fallback_refs)
@@ -140,5 +172,24 @@ class OllamaProvider(LLMProvider):
         payload = self._complete_json(
             system_prompt=build_finalize_system_prompt(),
             user_prompt=build_finalize_user_prompt(topics),
+            retry_example_payload={
+                "topics": [
+                    {
+                        "slug": "example-topic",
+                        "title": "Example Topic",
+                        "routing_description": "Use this skill when reviewing the finalized example workflow.",
+                        "summary": "Summarizes the finalized example workflow and its constraints.",
+                        "key_points": ["Follow the finalized example workflow in order."],
+                        "workflow_notes": ["Validate the finalized example output before reuse."],
+                        "references": [
+                            {
+                                "source_id": "example-source",
+                                "source_path": "/tmp/example-source.txt",
+                                "locator": "section 1",
+                            }
+                        ],
+                    }
+                ]
+            },
         )
         return parse_finalized_topics(payload, fallback_topics=topics)

--- a/src/digester/providers/openai_provider.py
+++ b/src/digester/providers/openai_provider.py
@@ -112,7 +112,7 @@ class OpenAIProvider(LLMProvider):
         except Exception as error:
             self._raise_openai_error(error)
 
-    def _complete_json(self, system_prompt: str, user_prompt: str) -> Dict[str, object]:
+    def _request_json_completion(self, system_prompt: str, user_prompt: str) -> str:
         client = self._client()
         self._log_request("OpenAI", self.model, system_prompt, user_prompt)
         started_at = perf_counter()
@@ -131,12 +131,64 @@ class OpenAIProvider(LLMProvider):
         if not content:
             raise ValueError("Model returned an empty response.")
         self._log_response("OpenAI", self.model, content, perf_counter() - started_at)
-        return self._parse_json_response("OpenAI", self.model, content)
+        return content
+
+    def _complete_json(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        retry_example_payload: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, object]:
+        content = self._request_json_completion(system_prompt=system_prompt, user_prompt=user_prompt)
+        try:
+            return self._parse_json_response("OpenAI", self.model, content)
+        except ValueError as error:
+            if "invalid JSON in the model response" not in str(error):
+                raise
+        self.progress_reporter.verbose(
+            "Verbose: OpenAI returned malformed JSON; retrying once with a stricter JSON-only instruction and a compact schema example."
+        )
+        if retry_example_payload is None:
+            retry_system_prompt = (
+                "{prompt} Return only one complete JSON object with no markdown fences, no commentary, "
+                "and no trailing text. Ensure every key, string, bracket, and brace is fully closed."
+            ).format(prompt=system_prompt)
+        else:
+            retry_system_prompt = self._build_retry_system_prompt(
+                system_prompt=system_prompt,
+                example_payload=retry_example_payload,
+            )
+        retry_content = self._request_json_completion(
+            system_prompt=retry_system_prompt,
+            user_prompt=user_prompt,
+        )
+        return self._parse_json_response("OpenAI", self.model, retry_content)
 
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
         payload = self._complete_json(
             system_prompt=build_digest_system_prompt(),
             user_prompt=build_digest_user_prompt(request),
+            retry_example_payload={
+                "topic_updates": [
+                    {
+                        "slug": "example-topic",
+                        "title": "Example Topic",
+                        "routing_description": "Use this skill when reviewing the example workflow.",
+                        "summary": "Summarizes the example workflow and its constraints.",
+                        "key_points": ["Follow the example workflow in order."],
+                        "workflow_notes": ["Validate the example output before reuse."],
+                        "references": [
+                            {
+                                "source_id": "example-source",
+                                "source_path": "/tmp/example-source.txt",
+                                "locator": "section 1",
+                            }
+                        ],
+                    }
+                ],
+                "should_continue": False,
+                "rationale": "Example rationale.",
+            },
         )
         fallback_refs = [chunk.source_ref for chunk in request.chunk_batch]
         return parse_digest_decision(payload, fallback_refs=fallback_refs)
@@ -147,5 +199,24 @@ class OpenAIProvider(LLMProvider):
         payload = self._complete_json(
             system_prompt=build_finalize_system_prompt(),
             user_prompt=build_finalize_user_prompt(topics),
+            retry_example_payload={
+                "topics": [
+                    {
+                        "slug": "example-topic",
+                        "title": "Example Topic",
+                        "routing_description": "Use this skill when reviewing the finalized example workflow.",
+                        "summary": "Summarizes the finalized example workflow and its constraints.",
+                        "key_points": ["Follow the finalized example workflow in order."],
+                        "workflow_notes": ["Validate the finalized example output before reuse."],
+                        "references": [
+                            {
+                                "source_id": "example-source",
+                                "source_path": "/tmp/example-source.txt",
+                                "locator": "section 1",
+                            }
+                        ],
+                    }
+                ]
+            },
         )
         return parse_finalized_topics(payload, fallback_topics=topics)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -615,6 +615,53 @@ def test_openai_provider_reports_invalid_json_with_context(monkeypatch) -> None:
     assert '<<<HERE>>>"<<<HERE>>>rationale' in message
 
 
+def test_openai_provider_retries_invalid_json_with_schema_example(monkeypatch) -> None:
+    provider = OpenAIProvider(model="gpt-5-nano", api_key="test-key")
+    reporter = RecordingVerboseReporter()
+    provider.set_progress_reporter(reporter)
+    invalid_content = '{"topic_updates": [], "should_continue": false "rationale": "broken"}'
+    valid_content = json.dumps(
+        {
+            "topic_updates": [],
+            "should_continue": False,
+            "rationale": "Recovered on retry.",
+        }
+    )
+    captured_calls = []
+
+    def fake_create(**kwargs):
+        captured_calls.append(kwargs)
+        content = invalid_content if len(captured_calls) == 1 else valid_content
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+        )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=fake_create)
+        )
+    )
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    decision = provider.digest_batch(
+        DigestBatchRequest(
+            config=DigestConfig(),
+            batch_number=1,
+            total_batches=1,
+            chunk_batch=[],
+            current_topics=[],
+        )
+    )
+
+    verbose_messages = [message for kind, message in reporter.messages if kind == "verbose"]
+    assert decision.rationale == "Recovered on retry."
+    assert len(captured_calls) == 2
+    retry_system_prompt = captured_calls[1]["messages"][0]["content"]
+    assert "Follow this exact JSON shape example:" in retry_system_prompt
+    assert '"topic_updates":[{' in retry_system_prompt
+    assert any("retrying once with a stricter JSON-only instruction and a compact schema example" in message for message in verbose_messages)
+
+
 def test_ollama_provider_reports_invalid_model_json_with_context(monkeypatch) -> None:
     provider = OllamaProvider(model="llama3.1")
     invalid_content = '{"topic_updates": [], "should_continue": false "rationale": "broken"}'
@@ -655,6 +702,60 @@ def test_ollama_provider_reports_invalid_model_json_with_context(monkeypatch) ->
     assert "Expecting ',' delimiter" in message
     assert "Received 69 chars." in message
     assert '<<<HERE>>>"<<<HERE>>>rationale' in message
+
+
+def test_ollama_provider_retries_invalid_json_with_schema_example(monkeypatch) -> None:
+    provider = OllamaProvider(model="llama3.1")
+    reporter = RecordingVerboseReporter()
+    provider.set_progress_reporter(reporter)
+    invalid_content = '{"topic_updates": [], "should_continue": false "rationale": "broken"}'
+    valid_content = json.dumps(
+        {
+            "topic_updates": [],
+            "should_continue": False,
+            "rationale": "Recovered on retry.",
+        }
+    )
+    captured_requests = []
+
+    class FakeResponse:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"message": {"content": self.content}}).encode("utf-8")
+
+    responses = iter([invalid_content, valid_content])
+
+    def fake_urlopen(request):
+        captured_requests.append(json.loads(request.data.decode("utf-8")))
+        return FakeResponse(next(responses))
+
+    monkeypatch.setattr("digester.providers.ollama_provider.urlopen", fake_urlopen)
+
+    decision = provider.digest_batch(
+        DigestBatchRequest(
+            config=DigestConfig(),
+            batch_number=1,
+            total_batches=1,
+            chunk_batch=[],
+            current_topics=[],
+        )
+    )
+
+    verbose_messages = [message for kind, message in reporter.messages if kind == "verbose"]
+    assert decision.rationale == "Recovered on retry."
+    assert len(captured_requests) == 2
+    retry_system_prompt = captured_requests[1]["messages"][0]["content"]
+    assert "Follow this exact JSON shape example:" in retry_system_prompt
+    assert '"topic_updates":[{' in retry_system_prompt
+    assert any("retrying once with a stricter JSON-only instruction and a compact schema example" in message for message in verbose_messages)
 
 
 def test_ollama_provider_reports_invalid_http_body_with_context(monkeypatch) -> None:


### PR DESCRIPTION
Summary:
- add a reusable retry-system prompt builder that includes a compact valid JSON example
- retry malformed structured responses for both Ollama and OpenAI-compatible providers with stronger schema guidance
- keep legacy direct _complete_json() call sites working while adding coverage for successful retry recovery
- align the local .venv with project dependencies so full local test runs include Pillow

Verification:
- ./.venv/bin/pytest -q tests/test_providers.py
- ./.venv/bin/pytest -q
- python -m compileall src

Fixes #27