### PR TITLE
Add stage-specific sampling controls

### DIFF
--- a/src/digester/images/factory.py
+++ b/src/digester/images/factory.py
@@ -19,6 +19,7 @@ class ImageAnalyzerSettings:
     ollama_host: str = "127.0.0.1"
     ollama_port: int = 11434
     timeout_seconds: Optional[int] = None
+    temperature: float = 0.0
 
 
 def create_image_analyzer(settings: ImageAnalyzerSettings) -> ImageAnalyzer:
@@ -27,6 +28,7 @@ def create_image_analyzer(settings: ImageAnalyzerSettings) -> ImageAnalyzer:
             model=settings.model,
             api_key=settings.api_key,
             organization=settings.organization,
+            temperature=settings.temperature,
         )
     if settings.analyzer_kind == "openai-compatible":
         if not settings.base_url:
@@ -36,6 +38,7 @@ def create_image_analyzer(settings: ImageAnalyzerSettings) -> ImageAnalyzer:
             api_key=settings.api_key,
             base_url=settings.base_url,
             organization=settings.organization,
+            temperature=settings.temperature,
         )
     if settings.analyzer_kind == "mock-image":
         return MockImageAnalyzer(model=settings.model)
@@ -45,5 +48,6 @@ def create_image_analyzer(settings: ImageAnalyzerSettings) -> ImageAnalyzer:
             host=settings.ollama_host,
             port=settings.ollama_port,
             timeout_seconds=settings.timeout_seconds,
+            temperature=settings.temperature,
         )
     raise ValueError("Unknown image analyzer kind: {kind}".format(kind=settings.analyzer_kind))

--- a/src/digester/images/ollama_image_analyzer.py
+++ b/src/digester/images/ollama_image_analyzer.py
@@ -30,12 +30,14 @@ class OllamaImageAnalyzer(ImageAnalyzer):
         host: str = "127.0.0.1",
         port: int = 11434,
         timeout_seconds: Optional[int] = None,
+        temperature: float = 0.0,
     ) -> None:
         super().__init__()
         self.model = model
         self.host = host
         self.port = port
         self.timeout_seconds = timeout_seconds
+        self.temperature = temperature
         self.base_url = _normalize_base_url(host=host, port=port)
         self._log_helper = _ImageLogHelper()
 
@@ -65,7 +67,7 @@ class OllamaImageAnalyzer(ImageAnalyzer):
                 "model": self.model,
                 "stream": False,
                 "format": "json",
-                "options": {"temperature": 0},
+                "options": {"temperature": self.temperature},
                 "messages": [
                     {"role": "system", "content": system_prompt},
                     {

--- a/src/digester/images/openai_image_analyzer.py
+++ b/src/digester/images/openai_image_analyzer.py
@@ -66,9 +66,11 @@ class OpenAIImageAnalyzer(ImageAnalyzer):
         api_key: str,
         base_url: Optional[str] = None,
         organization: Optional[str] = None,
+        temperature: float = 0.0,
     ) -> None:
         super().__init__()
         self.model = model
+        self.temperature = temperature
         self._client_provider = OpenAIProvider(
             model=model,
             api_key=api_key,
@@ -102,6 +104,7 @@ class OpenAIImageAnalyzer(ImageAnalyzer):
                         ],
                     },
                 ],
+                temperature=self.temperature,
                 response_format={"type": "json_object"},
             )
         except Exception as error:

--- a/src/digester/interfaces/cli.py
+++ b/src/digester/interfaces/cli.py
@@ -96,6 +96,24 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional request timeout in seconds for Ollama requests. Defaults to no timeout.",
     )
+    digest_parser.add_argument(
+        "--digest-temperature",
+        type=float,
+        default=float(os.getenv("BOOKWORM_DIGEST_TEMPERATURE", "0.4")),
+        help="Sampling temperature for digest-stage text generation.",
+    )
+    digest_parser.add_argument(
+        "--finalize-temperature",
+        type=float,
+        default=float(os.getenv("BOOKWORM_FINALIZE_TEMPERATURE", "0.1")),
+        help="Sampling temperature for finalize-stage text generation.",
+    )
+    digest_parser.add_argument(
+        "--image-temperature",
+        type=float,
+        default=float(os.getenv("BOOKWORM_IMAGE_TEMPERATURE", "0.0")),
+        help="Sampling temperature for image-analysis generation.",
+    )
     digest_parser.add_argument("--max-chunk-chars", type=int, default=1800)
     digest_parser.add_argument("--batch-size", type=int, default=2)
     digest_parser.add_argument("--minimum-batches-before-stop", type=int, default=2)
@@ -207,6 +225,7 @@ def _resolve_image_analyzer(args: argparse.Namespace) -> Optional[ImageAnalyzer]
             ollama_host=args.ollama_host,
             ollama_port=args.ollama_port,
             timeout_seconds=args.timeout_sc,
+            temperature=args.image_temperature,
         )
     )
 
@@ -271,6 +290,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 ollama_host=args.ollama_host,
                 ollama_port=args.ollama_port,
                 timeout_seconds=args.timeout_sc,
+                digest_temperature=args.digest_temperature,
+                finalize_temperature=args.finalize_temperature,
             )
         )
         image_analyzer = _resolve_image_analyzer(args)

--- a/src/digester/providers/factory.py
+++ b/src/digester/providers/factory.py
@@ -20,6 +20,8 @@ class ProviderSettings:
     ollama_host: str = "127.0.0.1"
     ollama_port: int = 11434
     timeout_seconds: Optional[int] = None
+    digest_temperature: float = 0.4
+    finalize_temperature: float = 0.1
 
 
 def create_provider(settings: ProviderSettings) -> LLMProvider:
@@ -28,12 +30,16 @@ def create_provider(settings: ProviderSettings) -> LLMProvider:
             model=settings.model,
             api_key=settings.api_key,
             organization=settings.organization,
+            digest_temperature=settings.digest_temperature,
+            finalize_temperature=settings.finalize_temperature,
         )
     if settings.provider_kind == "openai-compatible":
         return OpenAICompatibleProvider(
             model=settings.model,
             api_key=settings.api_key,
             base_url=settings.base_url or "",
+            digest_temperature=settings.digest_temperature,
+            finalize_temperature=settings.finalize_temperature,
         )
     if settings.provider_kind == "ollama":
         return OllamaProvider(
@@ -41,6 +47,8 @@ def create_provider(settings: ProviderSettings) -> LLMProvider:
             host=settings.ollama_host,
             port=settings.ollama_port,
             timeout_seconds=settings.timeout_seconds,
+            digest_temperature=settings.digest_temperature,
+            finalize_temperature=settings.finalize_temperature,
         )
     if settings.provider_kind == "mock-llm":
         return MockLLMProvider(model=settings.model)

--- a/src/digester/providers/ollama_provider.py
+++ b/src/digester/providers/ollama_provider.py
@@ -42,6 +42,8 @@ class OllamaProvider(LLMProvider):
         host: str = "127.0.0.1",
         port: int = 11434,
         timeout_seconds: Optional[int] = None,
+        digest_temperature: float = 0.4,
+        finalize_temperature: float = 0.1,
     ) -> None:
         super().__init__()
         self.model = model
@@ -49,15 +51,17 @@ class OllamaProvider(LLMProvider):
         self.port = port
         self.timeout_seconds = timeout_seconds
         self.base_url = _normalize_base_url(host=host, port=port)
+        self.digest_temperature = digest_temperature
+        self.finalize_temperature = finalize_temperature
 
-    def _request_content(self, system_prompt: str, user_prompt: str) -> str:
+    def _request_content(self, system_prompt: str, user_prompt: str, temperature: float) -> str:
         self._log_request("Ollama", self.model, system_prompt, user_prompt)
         payload = json.dumps(
             {
                 "model": self.model,
                 "stream": False,
                 "format": "json",
-                "options": {"temperature": 0},
+                "options": {"temperature": temperature},
                 "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
@@ -114,8 +118,13 @@ class OllamaProvider(LLMProvider):
         system_prompt: str,
         user_prompt: str,
         retry_example_payload: Optional[Dict[str, object]] = None,
+        temperature: float = 0,
     ) -> Dict[str, object]:
-        content = self._request_content(system_prompt=system_prompt, user_prompt=user_prompt)
+        content = self._request_content(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            temperature=temperature,
+        )
         try:
             return self._parse_json_response("Ollama", self.model, content)
         except ValueError as error:
@@ -134,7 +143,11 @@ class OllamaProvider(LLMProvider):
                 system_prompt=system_prompt,
                 example_payload=retry_example_payload,
             )
-        retry_content = self._request_content(system_prompt=retry_system_prompt, user_prompt=user_prompt)
+        retry_content = self._request_content(
+            system_prompt=retry_system_prompt,
+            user_prompt=user_prompt,
+            temperature=temperature,
+        )
         return self._parse_json_response("Ollama", self.model, retry_content)
 
     def digest_batch(self, request: DigestBatchRequest) -> DigestDecision:
@@ -162,6 +175,7 @@ class OllamaProvider(LLMProvider):
                 "should_continue": False,
                 "rationale": "Example rationale.",
             },
+            temperature=self.digest_temperature,
         )
         fallback_refs = [chunk.source_ref for chunk in request.chunk_batch]
         return parse_digest_decision(payload, fallback_refs=fallback_refs)
@@ -191,5 +205,6 @@ class OllamaProvider(LLMProvider):
                     }
                 ]
             },
+            temperature=self.finalize_temperature,
         )
         return parse_finalized_topics(payload, fallback_topics=topics)

--- a/src/digester/providers/openai_compatible.py
+++ b/src/digester/providers/openai_compatible.py
@@ -4,10 +4,23 @@ from .openai_provider import OpenAIProvider
 
 
 class OpenAICompatibleProvider(OpenAIProvider):
-    def __init__(self, model: str, api_key: str, base_url: str) -> None:
+    def __init__(
+        self,
+        model: str,
+        api_key: str,
+        base_url: str,
+        digest_temperature: float = 0.4,
+        finalize_temperature: float = 0.1,
+    ) -> None:
         if not base_url:
             raise ValueError("A base URL is required for openai-compatible providers.")
-        super().__init__(model=model, api_key=api_key, base_url=base_url)
+        super().__init__(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            digest_temperature=digest_temperature,
+            finalize_temperature=finalize_temperature,
+        )
 
     def validate_configuration(self) -> None:
         return None

--- a/src/digester/providers/openai_provider.py
+++ b/src/digester/providers/openai_provider.py
@@ -22,6 +22,8 @@ class OpenAIProvider(LLMProvider):
         api_key: str,
         base_url: Optional[str] = None,
         organization: Optional[str] = None,
+        digest_temperature: float = 0.4,
+        finalize_temperature: float = 0.1,
     ) -> None:
         super().__init__()
         if not api_key:
@@ -30,6 +32,8 @@ class OpenAIProvider(LLMProvider):
         self.api_key = api_key
         self.base_url = base_url
         self.organization = organization
+        self.digest_temperature = digest_temperature
+        self.finalize_temperature = finalize_temperature
 
     def _client(self):
         from openai import OpenAI
@@ -112,7 +116,7 @@ class OpenAIProvider(LLMProvider):
         except Exception as error:
             self._raise_openai_error(error)
 
-    def _request_json_completion(self, system_prompt: str, user_prompt: str) -> str:
+    def _request_json_completion(self, system_prompt: str, user_prompt: str, temperature: float) -> str:
         client = self._client()
         self._log_request("OpenAI", self.model, system_prompt, user_prompt)
         started_at = perf_counter()
@@ -123,6 +127,7 @@ class OpenAIProvider(LLMProvider):
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
+                temperature=temperature,
                 response_format={"type": "json_object"},
             )
         except Exception as error:
@@ -138,8 +143,13 @@ class OpenAIProvider(LLMProvider):
         system_prompt: str,
         user_prompt: str,
         retry_example_payload: Optional[Dict[str, object]] = None,
+        temperature: float = 0,
     ) -> Dict[str, object]:
-        content = self._request_json_completion(system_prompt=system_prompt, user_prompt=user_prompt)
+        content = self._request_json_completion(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            temperature=temperature,
+        )
         try:
             return self._parse_json_response("OpenAI", self.model, content)
         except ValueError as error:
@@ -161,6 +171,7 @@ class OpenAIProvider(LLMProvider):
         retry_content = self._request_json_completion(
             system_prompt=retry_system_prompt,
             user_prompt=user_prompt,
+            temperature=temperature,
         )
         return self._parse_json_response("OpenAI", self.model, retry_content)
 
@@ -189,6 +200,7 @@ class OpenAIProvider(LLMProvider):
                 "should_continue": False,
                 "rationale": "Example rationale.",
             },
+            temperature=self.digest_temperature,
         )
         fallback_refs = [chunk.source_ref for chunk in request.chunk_batch]
         return parse_digest_decision(payload, fallback_refs=fallback_refs)
@@ -218,5 +230,6 @@ class OpenAIProvider(LLMProvider):
                     }
                 ]
             },
+            temperature=self.finalize_temperature,
         )
         return parse_finalized_topics(payload, fallback_topics=topics)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,6 +588,7 @@ def test_cli_creates_configured_image_analyzer(monkeypatch, tmp_path: Path, caps
     def fake_create_image_analyzer(settings):
         seen["analyzer_kind"] = settings.analyzer_kind
         seen["model"] = settings.model
+        seen["temperature"] = settings.temperature
         return MockImageAnalyzer(model=settings.model)
 
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -616,6 +617,7 @@ def test_cli_creates_configured_image_analyzer(monkeypatch, tmp_path: Path, caps
     assert seen == {
         "analyzer_kind": "mock-image",
         "model": "fake-vision",
+        "temperature": 0.0,
     }
     assert "Using image analyzer mock-image with model fake-vision." in captured.err
 
@@ -678,6 +680,7 @@ def test_cli_configures_ollama_image_analyzer_without_api_key(monkeypatch, tmp_p
         seen["ollama_host"] = settings.ollama_host
         seen["ollama_port"] = settings.ollama_port
         seen["timeout_seconds"] = settings.timeout_seconds
+        seen["temperature"] = settings.temperature
         return MockImageAnalyzer(model=settings.model)
 
     monkeypatch.setattr(cli, "create_provider", lambda settings: CliFakeProvider())
@@ -703,6 +706,8 @@ def test_cli_configures_ollama_image_analyzer_without_api_key(monkeypatch, tmp_p
             "11435",
             "--timeout-sc",
             "60",
+            "--image-temperature",
+            "0.2",
         ]
     )
 
@@ -715,5 +720,43 @@ def test_cli_configures_ollama_image_analyzer_without_api_key(monkeypatch, tmp_p
         "ollama_host": "192.168.1.20",
         "ollama_port": 11435,
         "timeout_seconds": 60,
+        "temperature": 0.2,
     }
     assert "Using image analyzer ollama with model gemma3:4b." in captured.err
+
+
+def test_cli_passes_stage_specific_provider_temperatures(monkeypatch, tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "notes.txt"
+    input_path.write_text("A concise document.", encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+    seen = {}
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+
+    def fake_create_provider(settings: ProviderSettings):
+        seen["digest_temperature"] = settings.digest_temperature
+        seen["finalize_temperature"] = settings.finalize_temperature
+        return CliFakeProvider()
+
+    monkeypatch.setattr(cli, "create_provider", fake_create_provider)
+
+    exit_code = cli.main(
+        [
+            "digest",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--model",
+            "fake-model",
+            "--digest-temperature",
+            "0.6",
+            "--finalize-temperature",
+            "0.2",
+        ]
+    )
+
+    capsys.readouterr()
+    assert exit_code == 0
+    assert seen == {
+        "digest_temperature": 0.6,
+        "finalize_temperature": 0.2,
+    }

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -58,6 +58,19 @@ def test_create_image_analyzer_builds_ollama_image_analyzer() -> None:
     assert analyzer.timeout_seconds == 30
 
 
+def test_create_image_analyzer_passes_temperature() -> None:
+    analyzer = create_image_analyzer(
+        ImageAnalyzerSettings(
+            analyzer_kind="ollama",
+            model="gemma3:4b",
+            temperature=0.25,
+        )
+    )
+
+    assert isinstance(analyzer, OllamaImageAnalyzer)
+    assert analyzer.temperature == 0.25
+
+
 def test_mock_image_analyzer_preserves_caption_and_context() -> None:
     analyzer = MockImageAnalyzer(model="fake-vision")
 
@@ -134,6 +147,7 @@ def test_ollama_image_analyzer_sends_base64_image_and_parses_analysis(monkeypatc
     assert captured["payload"]["model"] == "gemma3:4b"
     assert captured["payload"]["stream"] is False
     assert captured["payload"]["format"] == "json"
+    assert captured["payload"]["options"]["temperature"] == 0.0
     assert captured["payload"]["messages"][1]["images"] == ["aW1hZ2UtYnl0ZXM="]
     assert result.summary == "The screenshot shows a confirmation dialog."
     assert result.key_points == ["The highlighted button is Continue."]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -81,6 +81,23 @@ def test_create_provider_passes_ollama_timeout() -> None:
     assert provider.timeout_seconds == 600
 
 
+def test_create_provider_passes_stage_specific_temperatures() -> None:
+    provider = create_provider(
+        ProviderSettings(
+            provider_kind="openai-compatible",
+            model="local-model",
+            api_key="test-key",
+            base_url="http://127.0.0.1:9000/v1",
+            digest_temperature=0.55,
+            finalize_temperature=0.15,
+        )
+    )
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.digest_temperature == 0.55
+    assert provider.finalize_temperature == 0.15
+
+
 def test_normalize_base_url_preserves_scheme_and_default_port() -> None:
     assert _normalize_base_url("127.0.0.1", 11434) == "http://127.0.0.1:11434"
     assert _normalize_base_url("http://10.0.0.8", 11434) == "http://10.0.0.8:11434"
@@ -201,6 +218,77 @@ def test_ollama_provider_digest_batch(monkeypatch) -> None:
         == "Use this skill when reviewing the locally digested overview."
     )
     assert decision.topic_updates[0].workflow_notes == ["Validate the local model output before reuse."]
+
+
+def test_ollama_provider_uses_stage_specific_temperatures(monkeypatch) -> None:
+    provider = OllamaProvider(
+        model="llama3.1",
+        digest_temperature=0.45,
+        finalize_temperature=0.05,
+    )
+    captured_payloads = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            payload = (
+                {
+                    "topic_updates": [],
+                    "should_continue": False,
+                    "rationale": "Enough evidence collected.",
+                }
+                if len(captured_payloads) == 1
+                else {
+                    "topics": [
+                        {
+                            "slug": "overview",
+                            "title": "Overview",
+                            "routing_description": "Use this skill when reviewing the finalized overview guidance.",
+                            "summary": "Summary.",
+                            "key_points": ["Point"],
+                            "workflow_notes": ["Note"],
+                            "references": [],
+                        }
+                    ]
+                }
+            )
+            return json.dumps({"message": {"content": json.dumps(payload)}}).encode("utf-8")
+
+    def fake_urlopen(request):
+        captured_payloads.append(json.loads(request.data.decode("utf-8")))
+        return FakeResponse()
+
+    monkeypatch.setattr("digester.providers.ollama_provider.urlopen", fake_urlopen)
+    provider.digest_batch(
+        DigestBatchRequest(
+            config=DigestConfig(),
+            batch_number=1,
+            total_batches=1,
+            chunk_batch=[],
+            current_topics=[],
+        )
+    )
+    provider.finalize_topics(
+        [
+            TopicDigest(
+                slug="overview",
+                title="Overview",
+                routing_description="Use this skill when reviewing the finalized overview guidance.",
+                summary="Summary.",
+                key_points=["Point"],
+                workflow_notes=["Note"],
+                references=[],
+            )
+        ]
+    )
+
+    assert captured_payloads[0]["options"]["temperature"] == 0.45
+    assert captured_payloads[1]["options"]["temperature"] == 0.05
 
 
 def test_ollama_provider_reports_connection_failure(monkeypatch) -> None:
@@ -581,6 +669,76 @@ def test_openai_provider_double_verbose_logging_keeps_full_body(monkeypatch) -> 
     assert any("request body" in message for message in verbose_messages)
     assert any(user_prompt in message for message in verbose_messages)
     assert not any("[omitted" in message for message in verbose_messages if "request body" in message)
+
+
+def test_openai_provider_uses_stage_specific_temperatures(monkeypatch) -> None:
+    provider = OpenAIProvider(
+        model="gpt-5-nano",
+        api_key="test-key",
+        digest_temperature=0.5,
+        finalize_temperature=0.2,
+    )
+    captured_calls = []
+
+    def fake_create(**kwargs):
+        captured_calls.append(kwargs)
+        payload = (
+            {
+                "topic_updates": [],
+                "should_continue": False,
+                "rationale": "Enough context collected.",
+            }
+            if len(captured_calls) == 1
+            else {
+                "topics": [
+                    {
+                        "slug": "overview",
+                        "title": "Overview",
+                        "routing_description": "Use this skill when reviewing finalized guidance.",
+                        "summary": "Summary.",
+                        "key_points": ["Point"],
+                        "workflow_notes": ["Note"],
+                        "references": [],
+                    }
+                ]
+            }
+        )
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=json.dumps(payload)))]
+        )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=fake_create)
+        )
+    )
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    provider.digest_batch(
+        DigestBatchRequest(
+            config=DigestConfig(),
+            batch_number=1,
+            total_batches=1,
+            chunk_batch=[],
+            current_topics=[],
+        )
+    )
+    provider.finalize_topics(
+        [
+            TopicDigest(
+                slug="overview",
+                title="Overview",
+                routing_description="Use this skill when reviewing finalized guidance.",
+                summary="Summary.",
+                key_points=["Point"],
+                workflow_notes=["Note"],
+                references=[],
+            )
+        ]
+    )
+
+    assert captured_calls[0]["temperature"] == 0.5
+    assert captured_calls[1]["temperature"] == 0.2
 
 
 def test_openai_provider_reports_invalid_json_with_context(monkeypatch) -> None:


### PR DESCRIPTION
Summary:
- add stage-specific digest/finalize temperature settings for Ollama and OpenAI-compatible providers
- add image analyzer temperature settings and CLI plumbing for digest/finalize/image stages
- cover provider factory, CLI wiring, and request payload defaults with tests

Verification:
- ./.venv/bin/pytest -q tests/test_providers.py tests/test_images.py tests/test_cli.py
- ./.venv/bin/pytest -q
- python -m compileall src

Fixes #28